### PR TITLE
[feat-teacher-main-api] 선생님 메인 페이지 API 구현

### DIFF
--- a/src/main/java/com/beelinkers/englebee/general/domain/repository/ExamRepository.java
+++ b/src/main/java/com/beelinkers/englebee/general/domain/repository/ExamRepository.java
@@ -2,6 +2,7 @@ package com.beelinkers.englebee.general.domain.repository;
 
 import com.beelinkers.englebee.general.domain.entity.Exam;
 import com.beelinkers.englebee.general.domain.entity.ExamStatus;
+import com.beelinkers.englebee.general.domain.entity.LectureStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,4 +12,7 @@ import java.util.List;
 public interface ExamRepository extends JpaRepository<Exam, Long> {
     Page<Exam> findByLectureStudentSeqAndStatus(Long memberSeq, ExamStatus status, Pageable pageable);
     Page<Exam> findByLectureStudentSeqAndStatusIn(Long memberSeq, List<ExamStatus> status, Pageable pageable);
+
+    Page<Exam> findByLectureTeacherSeqAndStatus(Long lecture_teacher_seq, ExamStatus status, Pageable pageable);
+
 }

--- a/src/main/java/com/beelinkers/englebee/general/domain/repository/ExamRepository.java
+++ b/src/main/java/com/beelinkers/englebee/general/domain/repository/ExamRepository.java
@@ -13,6 +13,6 @@ public interface ExamRepository extends JpaRepository<Exam, Long> {
     Page<Exam> findByLectureStudentSeqAndStatus(Long memberSeq, ExamStatus status, Pageable pageable);
     Page<Exam> findByLectureStudentSeqAndStatusIn(Long memberSeq, List<ExamStatus> status, Pageable pageable);
 
-    Page<Exam> findByLectureTeacherSeqAndStatus(Long lecture_teacher_seq, ExamStatus status, Pageable pageable);
-
+    Page<Exam> findByLectureTeacherSeqAndStatus(Long memberSeq, ExamStatus status, Pageable pageable);
+    Page<Exam> findByLectureTeacherSeqAndStatusNot(Long memberSeq, ExamStatus status, Pageable pageable);
 }

--- a/src/main/java/com/beelinkers/englebee/general/domain/repository/LectureRepository.java
+++ b/src/main/java/com/beelinkers/englebee/general/domain/repository/LectureRepository.java
@@ -9,5 +9,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface LectureRepository extends JpaRepository<Lecture, Long> {
     // 학생 수강 목록 조회
     Page<Lecture> findByStudentSeqAndStatus(Long studentSeq, LectureStatus status, Pageable pageable);
+    // 선생님 강의 목록 조회
+    Page<Lecture> findByTeacherSeqAndStatus(Long teacherSeq, LectureStatus status, Pageable pageable);
 }
 

--- a/src/main/java/com/beelinkers/englebee/student/service/impl/StudentMainServiceImpl.java
+++ b/src/main/java/com/beelinkers/englebee/student/service/impl/StudentMainServiceImpl.java
@@ -13,11 +13,14 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import java.util.List;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class StudentMainServiceImpl implements StudentMainService {
 
     private final LectureRepository lectureRepository;
@@ -26,24 +29,28 @@ public class StudentMainServiceImpl implements StudentMainService {
     private final StudentMainPageMapper studentMainPageMapper;
 
     @Override
+    @Transactional(readOnly=true)
     public Page<MainPageLectureDTO> getLectureList(Long memberSeq, Pageable pageable) {
         return lectureRepository.findByStudentSeqAndStatus(memberSeq, LectureStatus.CREATED, pageable)
                 .map(studentMainPageMapper::mainPageLectureDto);
     }
 
     @Override
+    @Transactional(readOnly=true)
     public Page<MainPageQuestionDTO> getQuestionList(Pageable pageable) {
         return questionRepository.findAll(pageable)
                 .map(studentMainPageMapper::mainPageQuestionDTO);
     }
 
     @Override
+    @Transactional(readOnly=true)
     public Page<MainPageNewExamDTO> getNewExamList(Long memberSeq, Pageable pageable) {
         return examRepository.findByLectureStudentSeqAndStatus(memberSeq,ExamStatus.PREPARED, pageable)
                 .map(studentMainPageMapper::mainPageNewExamDTO);
     }
 
     @Override
+    @Transactional(readOnly=true)
     public Page<MainPageSubmitExamDTO> getSubmitExamList(Long memberSeq, Pageable pageable) {
        return examRepository.findByLectureStudentSeqAndStatusIn(
                     memberSeq, List.of(ExamStatus.SUBMITTED, ExamStatus.FEEDBACK_COMPLETED), pageable

--- a/src/main/java/com/beelinkers/englebee/teacher/controller/api/TeacherMainApiController.java
+++ b/src/main/java/com/beelinkers/englebee/teacher/controller/api/TeacherMainApiController.java
@@ -2,6 +2,7 @@ package com.beelinkers.englebee.teacher.controller.api;
 
 import com.beelinkers.englebee.general.dto.response.GeneralPagedResponseDTO;
 import com.beelinkers.englebee.general.dto.response.PaginationResponseDTO;
+import com.beelinkers.englebee.teacher.dto.response.TeacherMainPageAuthoredExamDTO;
 import com.beelinkers.englebee.teacher.dto.response.TeacherMainPageLectureDTO;
 import com.beelinkers.englebee.teacher.dto.response.TeacherMainPageNewExamDTO;
 import com.beelinkers.englebee.teacher.dto.response.TeacherMainPageQuestionDTO;
@@ -73,5 +74,19 @@ public class TeacherMainApiController {
     return ResponseEntity.ok(pagedPagination);
   }
 
-
+  @GetMapping("/authored-exam")
+  public ResponseEntity<GeneralPagedResponseDTO<TeacherMainPageAuthoredExamDTO>> getAuthoredExamList(
+          @RequestParam("memberSeq") Long memberSeq, @PageableDefault(size = 10) Pageable pageable
+  ) {
+    Page<TeacherMainPageAuthoredExamDTO> authoredExamList = teacherMainService.getAuthoredExamList(memberSeq, pageable);
+    PaginationResponseDTO pagination = new PaginationResponseDTO(
+      authoredExamList.getNumber()+1, authoredExamList.getSize(), authoredExamList.getTotalPages(),
+      authoredExamList.getTotalElements(), authoredExamList.hasPrevious(), authoredExamList.hasNext()
+    );
+    GeneralPagedResponseDTO<TeacherMainPageAuthoredExamDTO> pagedPagination = new GeneralPagedResponseDTO<>(
+      authoredExamList.getContent(),
+      pagination
+    );
+    return ResponseEntity.ok(pagedPagination);
+  }
 }

--- a/src/main/java/com/beelinkers/englebee/teacher/controller/api/TeacherMainApiController.java
+++ b/src/main/java/com/beelinkers/englebee/teacher/controller/api/TeacherMainApiController.java
@@ -3,6 +3,7 @@ package com.beelinkers.englebee.teacher.controller.api;
 import com.beelinkers.englebee.general.dto.response.GeneralPagedResponseDTO;
 import com.beelinkers.englebee.general.dto.response.PaginationResponseDTO;
 import com.beelinkers.englebee.teacher.dto.response.TeacherMainPageLectureDTO;
+import com.beelinkers.englebee.teacher.dto.response.TeacherMainPageQuestionDTO;
 import com.beelinkers.englebee.teacher.service.TeacherMainService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -39,6 +40,21 @@ public class TeacherMainApiController {
     return ResponseEntity.ok(pagedPagination);
   }
 
+  @GetMapping("/question")
+  public ResponseEntity<GeneralPagedResponseDTO<TeacherMainPageQuestionDTO>> getQuestionList(
+          @PageableDefault(size = 10) Pageable pageable
+  ) {
+    Page<TeacherMainPageQuestionDTO> questionList = teacherMainService.getQuestionList(pageable);
+    PaginationResponseDTO pagination = new PaginationResponseDTO(
+            questionList.getNumber() + 1, questionList.getSize(), questionList.getTotalPages(),
+            questionList.getTotalElements(), questionList.hasPrevious(), questionList.hasNext()
+    );
+    GeneralPagedResponseDTO<TeacherMainPageQuestionDTO> pagedPagination = new GeneralPagedResponseDTO<>(
+            questionList.getContent(),
+            pagination
+    );
+    return ResponseEntity.ok(pagedPagination);
+  }
 
 
 

--- a/src/main/java/com/beelinkers/englebee/teacher/controller/api/TeacherMainApiController.java
+++ b/src/main/java/com/beelinkers/englebee/teacher/controller/api/TeacherMainApiController.java
@@ -3,6 +3,7 @@ package com.beelinkers.englebee.teacher.controller.api;
 import com.beelinkers.englebee.general.dto.response.GeneralPagedResponseDTO;
 import com.beelinkers.englebee.general.dto.response.PaginationResponseDTO;
 import com.beelinkers.englebee.teacher.dto.response.TeacherMainPageLectureDTO;
+import com.beelinkers.englebee.teacher.dto.response.TeacherMainPageNewExamDTO;
 import com.beelinkers.englebee.teacher.dto.response.TeacherMainPageQuestionDTO;
 import com.beelinkers.englebee.teacher.service.TeacherMainService;
 import lombok.RequiredArgsConstructor;
@@ -56,6 +57,21 @@ public class TeacherMainApiController {
     return ResponseEntity.ok(pagedPagination);
   }
 
+  @GetMapping("/new-exam")
+  public ResponseEntity<GeneralPagedResponseDTO<TeacherMainPageNewExamDTO>> getNewExamList(
+          @RequestParam("memberSeq") Long memberSeq, @PageableDefault(size = 10) Pageable pageable
+  ) {
+    Page<TeacherMainPageNewExamDTO> newExamList = teacherMainService.getNewExamList(memberSeq, pageable);
+    PaginationResponseDTO pagination = new PaginationResponseDTO(
+      newExamList.getNumber()+1, newExamList.getSize(), newExamList.getTotalPages(),
+            newExamList.getTotalElements(), newExamList.hasPrevious(), newExamList.hasNext()
+    );
+    GeneralPagedResponseDTO<TeacherMainPageNewExamDTO> pagedPagination = new GeneralPagedResponseDTO<>(
+      newExamList.getContent(),
+      pagination
+    );
+    return ResponseEntity.ok(pagedPagination);
+  }
 
 
 }

--- a/src/main/java/com/beelinkers/englebee/teacher/controller/api/TeacherMainApiController.java
+++ b/src/main/java/com/beelinkers/englebee/teacher/controller/api/TeacherMainApiController.java
@@ -1,9 +1,18 @@
 package com.beelinkers.englebee.teacher.controller.api;
 
+import com.beelinkers.englebee.general.dto.response.GeneralPagedResponseDTO;
+import com.beelinkers.englebee.general.dto.response.PaginationResponseDTO;
+import com.beelinkers.englebee.teacher.dto.response.TeacherMainPageLectureDTO;
 import com.beelinkers.englebee.teacher.service.TeacherMainService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
@@ -13,4 +22,24 @@ import org.springframework.web.bind.annotation.RestController;
 public class TeacherMainApiController {
 
   private final TeacherMainService teacherMainService;
+
+  @GetMapping("/lecture")
+  public ResponseEntity<GeneralPagedResponseDTO<TeacherMainPageLectureDTO>> getLectureList(
+          @RequestParam("memberSeq") Long memberSeq, @PageableDefault(size = 10) Pageable pageable
+  ) {
+    Page<TeacherMainPageLectureDTO> lectureList = teacherMainService.getLectureList(memberSeq, pageable);
+    PaginationResponseDTO pagination = new PaginationResponseDTO(
+            lectureList.getNumber() + 1, lectureList.getSize(), lectureList.getTotalPages(),
+            lectureList.getTotalElements(), lectureList.hasPrevious(), lectureList.hasNext()
+    );
+    GeneralPagedResponseDTO<TeacherMainPageLectureDTO> pagedPagination = new GeneralPagedResponseDTO<>(
+            lectureList.getContent(),
+            pagination
+    );
+    return ResponseEntity.ok(pagedPagination);
+  }
+
+
+
+
 }

--- a/src/main/java/com/beelinkers/englebee/teacher/dto/response/TeacherMainPageAuthoredExamDTO.java
+++ b/src/main/java/com/beelinkers/englebee/teacher/dto/response/TeacherMainPageAuthoredExamDTO.java
@@ -1,0 +1,16 @@
+package com.beelinkers.englebee.teacher.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TeacherMainPageAuthoredExamDTO {
+    private Long seq;
+    private Long lectureSeq;
+    private String studentNickname;
+    private String title;
+    private String status;
+}

--- a/src/main/java/com/beelinkers/englebee/teacher/dto/response/TeacherMainPageLectureDTO.java
+++ b/src/main/java/com/beelinkers/englebee/teacher/dto/response/TeacherMainPageLectureDTO.java
@@ -1,0 +1,20 @@
+package com.beelinkers.englebee.teacher.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TeacherMainPageLectureDTO {
+    private Long id;
+    private String studentNickname;
+    private String title;
+    private String status;
+    private LocalDateTime createdAt;
+    private List<List<String>> subjectLevelCode;
+}

--- a/src/main/java/com/beelinkers/englebee/teacher/dto/response/TeacherMainPageNewExamDTO.java
+++ b/src/main/java/com/beelinkers/englebee/teacher/dto/response/TeacherMainPageNewExamDTO.java
@@ -1,0 +1,16 @@
+package com.beelinkers.englebee.teacher.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TeacherMainPageNewExamDTO {
+    private Long seq;
+    private Long lectureSeq;
+    private String studentNickname;
+    private String title;
+    private String status;
+}

--- a/src/main/java/com/beelinkers/englebee/teacher/dto/response/TeacherMainPageQuestionDTO.java
+++ b/src/main/java/com/beelinkers/englebee/teacher/dto/response/TeacherMainPageQuestionDTO.java
@@ -1,0 +1,17 @@
+package com.beelinkers.englebee.teacher.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TeacherMainPageQuestionDTO {
+    private Long seq;
+    private String memberNickname;
+    private String title;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/beelinkers/englebee/teacher/dto/response/mapper/TeacherMainPageMapper.java
+++ b/src/main/java/com/beelinkers/englebee/teacher/dto/response/mapper/TeacherMainPageMapper.java
@@ -1,8 +1,10 @@
 package com.beelinkers.englebee.teacher.dto.response.mapper;
 
+import com.beelinkers.englebee.general.domain.entity.Exam;
 import com.beelinkers.englebee.general.domain.entity.Lecture;
 import com.beelinkers.englebee.general.domain.entity.Question;
 import com.beelinkers.englebee.teacher.dto.response.TeacherMainPageLectureDTO;
+import com.beelinkers.englebee.teacher.dto.response.TeacherMainPageNewExamDTO;
 import com.beelinkers.englebee.teacher.dto.response.TeacherMainPageQuestionDTO;
 import org.springframework.stereotype.Component;
 
@@ -36,6 +38,18 @@ public class TeacherMainPageMapper {
                 question.getMember().getNickname(),
                 question.getTitle(),
                 question.getCreatedAt()
+        );
+    }
+
+    // main > new-exam
+    public TeacherMainPageNewExamDTO teacherMainPageNewExamDto(Exam exam) {
+        String studentNickname = exam.getLecture().getStudent().getNickname();
+        return new TeacherMainPageNewExamDTO(
+                exam.getSeq(),
+                exam.getLecture().getSeq(),
+                studentNickname,
+                exam.getTitle(),
+                exam.getStatus().name()
         );
     }
 

--- a/src/main/java/com/beelinkers/englebee/teacher/dto/response/mapper/TeacherMainPageMapper.java
+++ b/src/main/java/com/beelinkers/englebee/teacher/dto/response/mapper/TeacherMainPageMapper.java
@@ -1,7 +1,9 @@
 package com.beelinkers.englebee.teacher.dto.response.mapper;
 
 import com.beelinkers.englebee.general.domain.entity.Lecture;
+import com.beelinkers.englebee.general.domain.entity.Question;
 import com.beelinkers.englebee.teacher.dto.response.TeacherMainPageLectureDTO;
+import com.beelinkers.englebee.teacher.dto.response.TeacherMainPageQuestionDTO;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -26,6 +28,17 @@ public class TeacherMainPageMapper {
             subjectLevelCode
         );
     }
+
+    // main > Q&A
+    public TeacherMainPageQuestionDTO teacherMainPageQuestionDto(Question question) {
+        return new TeacherMainPageQuestionDTO(
+                question.getSeq(),
+                question.getMember().getNickname(),
+                question.getTitle(),
+                question.getCreatedAt()
+        );
+    }
+
 
 
 

--- a/src/main/java/com/beelinkers/englebee/teacher/dto/response/mapper/TeacherMainPageMapper.java
+++ b/src/main/java/com/beelinkers/englebee/teacher/dto/response/mapper/TeacherMainPageMapper.java
@@ -1,0 +1,32 @@
+package com.beelinkers.englebee.teacher.dto.response.mapper;
+
+import com.beelinkers.englebee.general.domain.entity.Lecture;
+import com.beelinkers.englebee.teacher.dto.response.TeacherMainPageLectureDTO;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+public class TeacherMainPageMapper {
+    // main > lecture
+    public TeacherMainPageLectureDTO teacherMainPageLectureDto(Lecture lecture) {
+        List<List<String>> subjectLevelCode = lecture.getSubjectLevels().stream()
+        .map( lectureSubjectLevel -> List.of(
+            lectureSubjectLevel.getSubjectLevel().getSubjectCode().getKoreanCode(),
+            lectureSubjectLevel.getSubjectLevel().getLevelCode().getKoreanCode()
+        ))
+        .collect(Collectors.toList());
+        return new TeacherMainPageLectureDTO(
+            lecture.getSeq(),
+            lecture.getStudent().getNickname(),
+            lecture.getTitle(),
+            lecture.getStatus().name(),
+            lecture.getCreatedAt(),
+            subjectLevelCode
+        );
+    }
+
+
+
+}

--- a/src/main/java/com/beelinkers/englebee/teacher/dto/response/mapper/TeacherMainPageMapper.java
+++ b/src/main/java/com/beelinkers/englebee/teacher/dto/response/mapper/TeacherMainPageMapper.java
@@ -3,6 +3,7 @@ package com.beelinkers.englebee.teacher.dto.response.mapper;
 import com.beelinkers.englebee.general.domain.entity.Exam;
 import com.beelinkers.englebee.general.domain.entity.Lecture;
 import com.beelinkers.englebee.general.domain.entity.Question;
+import com.beelinkers.englebee.teacher.dto.response.TeacherMainPageAuthoredExamDTO;
 import com.beelinkers.englebee.teacher.dto.response.TeacherMainPageLectureDTO;
 import com.beelinkers.englebee.teacher.dto.response.TeacherMainPageNewExamDTO;
 import com.beelinkers.englebee.teacher.dto.response.TeacherMainPageQuestionDTO;
@@ -53,7 +54,16 @@ public class TeacherMainPageMapper {
         );
     }
 
-
-
+    // main > authored-exam
+    public TeacherMainPageAuthoredExamDTO teacherMainPageAuthoredExamDTO(Exam exam) {
+        String studentNickname = exam.getLecture().getStudent().getNickname();
+        return new TeacherMainPageAuthoredExamDTO(
+                exam.getSeq(),
+                exam.getLecture().getSeq(),
+                studentNickname,
+                exam.getTitle(),
+                exam.getStatus().name()
+        );
+    }
 
 }

--- a/src/main/java/com/beelinkers/englebee/teacher/service/TeacherMainService.java
+++ b/src/main/java/com/beelinkers/englebee/teacher/service/TeacherMainService.java
@@ -1,5 +1,9 @@
 package com.beelinkers.englebee.teacher.service;
 
-public interface TeacherMainService {
+import com.beelinkers.englebee.teacher.dto.response.TeacherMainPageLectureDTO;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
+public interface TeacherMainService {
+    Page<TeacherMainPageLectureDTO> getLectureList(Long memberSeq, Pageable pageable);
 }

--- a/src/main/java/com/beelinkers/englebee/teacher/service/TeacherMainService.java
+++ b/src/main/java/com/beelinkers/englebee/teacher/service/TeacherMainService.java
@@ -1,9 +1,11 @@
 package com.beelinkers.englebee.teacher.service;
 
 import com.beelinkers.englebee.teacher.dto.response.TeacherMainPageLectureDTO;
+import com.beelinkers.englebee.teacher.dto.response.TeacherMainPageQuestionDTO;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface TeacherMainService {
     Page<TeacherMainPageLectureDTO> getLectureList(Long memberSeq, Pageable pageable);
+    Page<TeacherMainPageQuestionDTO> getQuestionList(Pageable pageable);
 }

--- a/src/main/java/com/beelinkers/englebee/teacher/service/TeacherMainService.java
+++ b/src/main/java/com/beelinkers/englebee/teacher/service/TeacherMainService.java
@@ -1,5 +1,6 @@
 package com.beelinkers.englebee.teacher.service;
 
+import com.beelinkers.englebee.teacher.dto.response.TeacherMainPageAuthoredExamDTO;
 import com.beelinkers.englebee.teacher.dto.response.TeacherMainPageLectureDTO;
 import com.beelinkers.englebee.teacher.dto.response.TeacherMainPageNewExamDTO;
 import com.beelinkers.englebee.teacher.dto.response.TeacherMainPageQuestionDTO;
@@ -10,4 +11,5 @@ public interface TeacherMainService {
     Page<TeacherMainPageLectureDTO> getLectureList(Long memberSeq, Pageable pageable);
     Page<TeacherMainPageQuestionDTO> getQuestionList(Pageable pageable);
     Page<TeacherMainPageNewExamDTO> getNewExamList(Long memberSeq, Pageable pageable);
+    Page<TeacherMainPageAuthoredExamDTO> getAuthoredExamList(Long memberSeq, Pageable pageable);
 }

--- a/src/main/java/com/beelinkers/englebee/teacher/service/TeacherMainService.java
+++ b/src/main/java/com/beelinkers/englebee/teacher/service/TeacherMainService.java
@@ -1,6 +1,7 @@
 package com.beelinkers.englebee.teacher.service;
 
 import com.beelinkers.englebee.teacher.dto.response.TeacherMainPageLectureDTO;
+import com.beelinkers.englebee.teacher.dto.response.TeacherMainPageNewExamDTO;
 import com.beelinkers.englebee.teacher.dto.response.TeacherMainPageQuestionDTO;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -8,4 +9,5 @@ import org.springframework.data.domain.Pageable;
 public interface TeacherMainService {
     Page<TeacherMainPageLectureDTO> getLectureList(Long memberSeq, Pageable pageable);
     Page<TeacherMainPageQuestionDTO> getQuestionList(Pageable pageable);
+    Page<TeacherMainPageNewExamDTO> getNewExamList(Long memberSeq, Pageable pageable);
 }

--- a/src/main/java/com/beelinkers/englebee/teacher/service/impl/TeacherMainServiceImpl.java
+++ b/src/main/java/com/beelinkers/englebee/teacher/service/impl/TeacherMainServiceImpl.java
@@ -1,9 +1,12 @@
 package com.beelinkers.englebee.teacher.service.impl;
 
+import com.beelinkers.englebee.general.domain.entity.ExamStatus;
 import com.beelinkers.englebee.general.domain.entity.LectureStatus;
+import com.beelinkers.englebee.general.domain.repository.ExamRepository;
 import com.beelinkers.englebee.general.domain.repository.LectureRepository;
 import com.beelinkers.englebee.general.domain.repository.QuestionRepository;
 import com.beelinkers.englebee.teacher.dto.response.TeacherMainPageLectureDTO;
+import com.beelinkers.englebee.teacher.dto.response.TeacherMainPageNewExamDTO;
 import com.beelinkers.englebee.teacher.dto.response.TeacherMainPageQuestionDTO;
 import com.beelinkers.englebee.teacher.dto.response.mapper.TeacherMainPageMapper;
 import com.beelinkers.englebee.teacher.service.TeacherMainService;
@@ -21,6 +24,7 @@ public class TeacherMainServiceImpl implements TeacherMainService {
     private final TeacherMainPageMapper teacherMainPageMapper;
     private final LectureRepository lectureRepository;
     private final QuestionRepository questionRepository;
+    private final ExamRepository examRepository;
 
     // lecture
     @Override
@@ -34,6 +38,13 @@ public class TeacherMainServiceImpl implements TeacherMainService {
     public Page<TeacherMainPageQuestionDTO> getQuestionList(Pageable pageable) {
         return questionRepository.findAll(pageable)
                 .map(teacherMainPageMapper::teacherMainPageQuestionDto);
+    }
+
+    // new-exam
+    @Override
+    public Page<TeacherMainPageNewExamDTO> getNewExamList(Long memberSeq, Pageable pageable) {
+        return examRepository.findByLectureTeacherSeqAndStatus(memberSeq, ExamStatus.CREATED, pageable)
+                .map(teacherMainPageMapper::teacherMainPageNewExamDto);
     }
 
 }

--- a/src/main/java/com/beelinkers/englebee/teacher/service/impl/TeacherMainServiceImpl.java
+++ b/src/main/java/com/beelinkers/englebee/teacher/service/impl/TeacherMainServiceImpl.java
@@ -5,6 +5,7 @@ import com.beelinkers.englebee.general.domain.entity.LectureStatus;
 import com.beelinkers.englebee.general.domain.repository.ExamRepository;
 import com.beelinkers.englebee.general.domain.repository.LectureRepository;
 import com.beelinkers.englebee.general.domain.repository.QuestionRepository;
+import com.beelinkers.englebee.teacher.dto.response.TeacherMainPageAuthoredExamDTO;
 import com.beelinkers.englebee.teacher.dto.response.TeacherMainPageLectureDTO;
 import com.beelinkers.englebee.teacher.dto.response.TeacherMainPageNewExamDTO;
 import com.beelinkers.englebee.teacher.dto.response.TeacherMainPageQuestionDTO;
@@ -45,6 +46,13 @@ public class TeacherMainServiceImpl implements TeacherMainService {
     public Page<TeacherMainPageNewExamDTO> getNewExamList(Long memberSeq, Pageable pageable) {
         return examRepository.findByLectureTeacherSeqAndStatus(memberSeq, ExamStatus.CREATED, pageable)
                 .map(teacherMainPageMapper::teacherMainPageNewExamDto);
+    }
+
+    // authored-exam
+    @Override
+    public Page<TeacherMainPageAuthoredExamDTO> getAuthoredExamList(Long memberSeq, Pageable pageable) {
+        return examRepository.findByLectureTeacherSeqAndStatusNot(memberSeq, ExamStatus.CREATED, pageable)
+                .map(teacherMainPageMapper::teacherMainPageAuthoredExamDTO);
     }
 
 }

--- a/src/main/java/com/beelinkers/englebee/teacher/service/impl/TeacherMainServiceImpl.java
+++ b/src/main/java/com/beelinkers/englebee/teacher/service/impl/TeacherMainServiceImpl.java
@@ -2,7 +2,9 @@ package com.beelinkers.englebee.teacher.service.impl;
 
 import com.beelinkers.englebee.general.domain.entity.LectureStatus;
 import com.beelinkers.englebee.general.domain.repository.LectureRepository;
+import com.beelinkers.englebee.general.domain.repository.QuestionRepository;
 import com.beelinkers.englebee.teacher.dto.response.TeacherMainPageLectureDTO;
+import com.beelinkers.englebee.teacher.dto.response.TeacherMainPageQuestionDTO;
 import com.beelinkers.englebee.teacher.dto.response.mapper.TeacherMainPageMapper;
 import com.beelinkers.englebee.teacher.service.TeacherMainService;
 import lombok.RequiredArgsConstructor;
@@ -16,8 +18,9 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class TeacherMainServiceImpl implements TeacherMainService {
 
-    private final LectureRepository lectureRepository;
     private final TeacherMainPageMapper teacherMainPageMapper;
+    private final LectureRepository lectureRepository;
+    private final QuestionRepository questionRepository;
 
     // lecture
     @Override
@@ -26,6 +29,11 @@ public class TeacherMainServiceImpl implements TeacherMainService {
                 .map(teacherMainPageMapper::teacherMainPageLectureDto);
     }
 
-
+    // question
+    @Override
+    public Page<TeacherMainPageQuestionDTO> getQuestionList(Pageable pageable) {
+        return questionRepository.findAll(pageable)
+                .map(teacherMainPageMapper::teacherMainPageQuestionDto);
+    }
 
 }

--- a/src/main/java/com/beelinkers/englebee/teacher/service/impl/TeacherMainServiceImpl.java
+++ b/src/main/java/com/beelinkers/englebee/teacher/service/impl/TeacherMainServiceImpl.java
@@ -1,11 +1,31 @@
 package com.beelinkers.englebee.teacher.service.impl;
 
+import com.beelinkers.englebee.general.domain.entity.LectureStatus;
+import com.beelinkers.englebee.general.domain.repository.LectureRepository;
+import com.beelinkers.englebee.teacher.dto.response.TeacherMainPageLectureDTO;
+import com.beelinkers.englebee.teacher.dto.response.mapper.TeacherMainPageMapper;
 import com.beelinkers.englebee.teacher.service.TeacherMainService;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Slf4j
 @Service
+@RequiredArgsConstructor
 public class TeacherMainServiceImpl implements TeacherMainService {
+
+    private final LectureRepository lectureRepository;
+    private final TeacherMainPageMapper teacherMainPageMapper;
+
+    // lecture
+    @Override
+    public Page<TeacherMainPageLectureDTO> getLectureList(Long memberSeq, Pageable pageable) {
+        return lectureRepository.findByTeacherSeqAndStatus(memberSeq, LectureStatus.CREATED, pageable)
+                .map(teacherMainPageMapper::teacherMainPageLectureDto);
+    }
+
+
 
 }

--- a/src/test/java/com/beelinkers/englebee/teacher/controller/api/TeacherMainApiControllerTest.java
+++ b/src/test/java/com/beelinkers/englebee/teacher/controller/api/TeacherMainApiControllerTest.java
@@ -1,6 +1,7 @@
 package com.beelinkers.englebee.teacher.controller.api;
 
 import com.beelinkers.englebee.teacher.dto.response.TeacherMainPageLectureDTO;
+import com.beelinkers.englebee.teacher.dto.response.TeacherMainPageNewExamDTO;
 import com.beelinkers.englebee.teacher.dto.response.TeacherMainPageQuestionDTO;
 import com.beelinkers.englebee.teacher.service.TeacherMainService;
 import org.junit.jupiter.api.BeforeEach;
@@ -39,19 +40,23 @@ public class TeacherMainApiControllerTest {
     @BeforeEach
     void setUp() {
         Page<TeacherMainPageLectureDTO> lecturePage = new PageImpl<>(List.of(new TeacherMainPageLectureDTO(
-                1L, "user3", "기초문법강의", "CREATED",
-                LocalDateTime.now(), List.of(List.of("어법", "중"), List.of("문장", "중"))
-        ))
-        );
+            1L, "user3", "기초문법강의", "CREATED",
+            LocalDateTime.now(), List.of(List.of("어법", "중"), List.of("문장", "중"))
+        )));
         Page<TeacherMainPageQuestionDTO> questionPage = new PageImpl<>(List.of(new TeacherMainPageQuestionDTO(
-                1L, "user2", "REST API 모범 사례", LocalDateTime.now()
-        ))
-        );
+            1L, "user2", "REST API 모범 사례", LocalDateTime.now()
+        )));
+        Page<TeacherMainPageNewExamDTO> newExamPage = new PageImpl<>(List.of(new TeacherMainPageNewExamDTO(
+            1L, 1L, "user2", "new 시험", "PREPARED"
+        )));
+
 
         Mockito.when(teacherMainService.getLectureList(anyLong(), any(Pageable.class)))
                 .thenReturn(lecturePage);
         Mockito.when(teacherMainService.getQuestionList(any(Pageable.class)))
                 .thenReturn(questionPage);
+        Mockito.when(teacherMainService.getNewExamList(anyLong(), any(Pageable.class)))
+                .thenReturn(newExamPage);
     }
 
     @Test
@@ -87,6 +92,21 @@ public class TeacherMainApiControllerTest {
             .andExpect(jsonPath("$.content[0].title").value("REST API 모범 사례"))
             .andExpect(jsonPath("$.content[0].createdAt").exists())
             .andExpect(jsonPath("$.pagination.currentPage").value(1)
+        );
+    }
+
+    @Test
+    void testGetNewExamList() throws Exception {
+        mockMvc.perform(get("/api/teacher/main/new-exam")
+            .param("memberSeq", "3")
+            .param("page", "0")
+            .param("size", "10")
+            .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.content").isArray())
+            .andExpect(jsonPath("$.content[0].studentNickname").value("user2"))
+            .andExpect(jsonPath("$.content[0].title").value("new 시험"))
+            .andExpect(jsonPath("$.content[0].status").value("PREPARED")
         );
     }
 }

--- a/src/test/java/com/beelinkers/englebee/teacher/controller/api/TeacherMainApiControllerTest.java
+++ b/src/test/java/com/beelinkers/englebee/teacher/controller/api/TeacherMainApiControllerTest.java
@@ -40,6 +40,7 @@ public class TeacherMainApiControllerTest {
 
     @BeforeEach
     void setUp() {
+        // given
         Page<TeacherMainPageLectureDTO> lecturePage = new PageImpl<>(List.of(new TeacherMainPageLectureDTO(
             1L, "user3", "기초문법강의", "CREATED",
             LocalDateTime.now(), List.of(List.of("어법", "중"), List.of("문장", "중"))
@@ -67,11 +68,13 @@ public class TeacherMainApiControllerTest {
     @Test
     @DisplayName("강의 목록 조회 API 테스트")
     void 강의_목록_조회_API_테스트() throws Exception {
+        //when
         mockMvc.perform(get("/api/teacher/main/lecture")
             .param("memberSeq", "3")
             .param("page", "0")
             .param("size", "10")
             .contentType(MediaType.APPLICATION_JSON))
+            //then
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.content").isArray())
             .andExpect(jsonPath("$.content[0].title").value("기초문법강의"))
@@ -87,54 +90,59 @@ public class TeacherMainApiControllerTest {
     @Test
     @DisplayName("질문 목록 조회 API 테스트")
     void 질문_목록_조회_API_테스트() throws Exception {
+        //when
         mockMvc.perform(get("/api/teacher/main/question")
-        .param("page", "0")
-        .param("size", "10")
-        .contentType(MediaType.APPLICATION_JSON))
-        .andExpect(status().isOk())
-        .andExpect(jsonPath("$.content").isArray())
-        .andExpect(jsonPath("$.content[0].memberNickname").value("user2"))
-        .andExpect(jsonPath("$.content[0].title").value("REST API 모범 사례"))
-        .andExpect(jsonPath("$.content[0].createdAt").exists())
-        .andExpect(jsonPath("$.pagination.totalPages").value(1))
-        .andExpect(jsonPath("$.pagination.totalElements").value(1))
-        .andExpect(jsonPath("$.pagination.currentPage").value(1));
-        ;
+            .param("page", "0")
+            .param("size", "10")
+            .contentType(MediaType.APPLICATION_JSON))
+            //then
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.content").isArray())
+            .andExpect(jsonPath("$.content[0].memberNickname").value("user2"))
+            .andExpect(jsonPath("$.content[0].title").value("REST API 모범 사례"))
+            .andExpect(jsonPath("$.content[0].createdAt").exists())
+            .andExpect(jsonPath("$.pagination.totalPages").value(1))
+            .andExpect(jsonPath("$.pagination.totalElements").value(1))
+            .andExpect(jsonPath("$.pagination.currentPage").value(1));
     }
 
     @Test
     @DisplayName("출제 할 문제 목록 API 테스트")
     void 출제_할_문제_목록_API_테스트() throws Exception {
+        //when
         mockMvc.perform(get("/api/teacher/main/new-exam")
-        .param("memberSeq", "3")
-        .param("page", "0")
-        .param("size", "10")
-        .contentType(MediaType.APPLICATION_JSON))
-        .andExpect(status().isOk())
-        .andExpect(jsonPath("$.content").isArray())
-        .andExpect(jsonPath("$.content[0].studentNickname").value("user2"))
-        .andExpect(jsonPath("$.content[0].title").value("new 시험"))
-        .andExpect(jsonPath("$.content[0].status").value("PREPARED"))
-        .andExpect(jsonPath("$.pagination.totalPages").value(1))
-        .andExpect(jsonPath("$.pagination.totalElements").value(1))
-        .andExpect(jsonPath("$.pagination.currentPage").value(1));
+            .param("memberSeq", "3")
+            .param("page", "0")
+            .param("size", "10")
+            .contentType(MediaType.APPLICATION_JSON))
+            //then
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.content").isArray())
+            .andExpect(jsonPath("$.content[0].studentNickname").value("user2"))
+            .andExpect(jsonPath("$.content[0].title").value("new 시험"))
+            .andExpect(jsonPath("$.content[0].status").value("PREPARED"))
+            .andExpect(jsonPath("$.pagination.totalPages").value(1))
+            .andExpect(jsonPath("$.pagination.totalElements").value(1))
+            .andExpect(jsonPath("$.pagination.currentPage").value(1));
     }
 
     @Test
     @DisplayName("출제 한 목록 조회 API 테스트")
     void 출제_한_목록_조회_API_테스트() throws Exception {
+        //when
         mockMvc.perform(get("/api/teacher/main/authored-exam")
-        .param("memberSeq", "3")
-        .param("page", "0")
-        .param("size", "10")
-        .contentType(MediaType.APPLICATION_JSON))
-        .andExpect(status().isOk())
-        .andExpect(jsonPath("$.content").isArray())
-        .andExpect(jsonPath("$.content[0].studentNickname").value("user2"))
-        .andExpect(jsonPath("$.content[0].title").value("new 시험"))
-        .andExpect(jsonPath("$.content[0].status").value("FEEDBACK_COMPLETED"))
-        .andExpect(jsonPath("$.pagination.totalPages").value(1))
-        .andExpect(jsonPath("$.pagination.totalElements").value(1))
-        .andExpect(jsonPath("$.pagination.currentPage").value(1));
+            .param("memberSeq", "3")
+            .param("page", "0")
+            .param("size", "10")
+            .contentType(MediaType.APPLICATION_JSON))
+            //then
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.content").isArray())
+            .andExpect(jsonPath("$.content[0].studentNickname").value("user2"))
+            .andExpect(jsonPath("$.content[0].title").value("new 시험"))
+            .andExpect(jsonPath("$.content[0].status").value("FEEDBACK_COMPLETED"))
+            .andExpect(jsonPath("$.pagination.totalPages").value(1))
+            .andExpect(jsonPath("$.pagination.totalElements").value(1))
+            .andExpect(jsonPath("$.pagination.currentPage").value(1));
     }
 }

--- a/src/test/java/com/beelinkers/englebee/teacher/controller/api/TeacherMainApiControllerTest.java
+++ b/src/test/java/com/beelinkers/englebee/teacher/controller/api/TeacherMainApiControllerTest.java
@@ -1,10 +1,12 @@
 package com.beelinkers.englebee.teacher.controller.api;
 
+import com.beelinkers.englebee.teacher.dto.response.TeacherMainPageAuthoredExamDTO;
 import com.beelinkers.englebee.teacher.dto.response.TeacherMainPageLectureDTO;
 import com.beelinkers.englebee.teacher.dto.response.TeacherMainPageNewExamDTO;
 import com.beelinkers.englebee.teacher.dto.response.TeacherMainPageQuestionDTO;
 import com.beelinkers.englebee.teacher.service.TeacherMainService;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,7 +27,6 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -49,7 +50,9 @@ public class TeacherMainApiControllerTest {
         Page<TeacherMainPageNewExamDTO> newExamPage = new PageImpl<>(List.of(new TeacherMainPageNewExamDTO(
             1L, 1L, "user2", "new 시험", "PREPARED"
         )));
-
+        Page<TeacherMainPageAuthoredExamDTO> quthoredExamPage = new PageImpl<>(List.of(new TeacherMainPageAuthoredExamDTO(
+            1L, 1L, "user2", "new 시험", "FEEDBACK_COMPLETED"
+        )));
 
         Mockito.when(teacherMainService.getLectureList(anyLong(), any(Pageable.class)))
                 .thenReturn(lecturePage);
@@ -57,10 +60,13 @@ public class TeacherMainApiControllerTest {
                 .thenReturn(questionPage);
         Mockito.when(teacherMainService.getNewExamList(anyLong(), any(Pageable.class)))
                 .thenReturn(newExamPage);
+        Mockito.when(teacherMainService.getAuthoredExamList(anyLong(), any(Pageable.class)))
+                .thenReturn(quthoredExamPage);
     }
 
     @Test
-    void testGetLectureList() throws Exception {
+    @DisplayName("강의 목록 조회 API 테스트")
+    void 강의_목록_조회_API_테스트() throws Exception {
         mockMvc.perform(get("/api/teacher/main/lecture")
             .param("memberSeq", "3")
             .param("page", "0")
@@ -73,40 +79,62 @@ public class TeacherMainApiControllerTest {
             .andExpect(jsonPath("$.content[0].createdAt").exists())
             .andExpect(jsonPath("$.content[0].subjectLevelCode[0][0]").value("어법"))
             .andExpect(jsonPath("$.content[0].subjectLevelCode[0][1]").value("중"))
-            .andExpect(jsonPath("$.pagination").exists())
             .andExpect(jsonPath("$.pagination.totalPages").value(1))
             .andExpect(jsonPath("$.pagination.totalElements").value(1))
-            .andExpect(jsonPath("$.pagination.currentPage").value(1)
-        );
+            .andExpect(jsonPath("$.pagination.currentPage").value(1));
     }
 
     @Test
-    void testGetQuestionList() throws Exception {
+    @DisplayName("질문 목록 조회 API 테스트")
+    void 질문_목록_조회_API_테스트() throws Exception {
         mockMvc.perform(get("/api/teacher/main/question")
-            .param("page", "0")
-            .param("size", "10")
-            .contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.content").isArray())
-            .andExpect(jsonPath("$.content[0].memberNickname").value("user2"))
-            .andExpect(jsonPath("$.content[0].title").value("REST API 모범 사례"))
-            .andExpect(jsonPath("$.content[0].createdAt").exists())
-            .andExpect(jsonPath("$.pagination.currentPage").value(1)
-        );
+        .param("page", "0")
+        .param("size", "10")
+        .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.content").isArray())
+        .andExpect(jsonPath("$.content[0].memberNickname").value("user2"))
+        .andExpect(jsonPath("$.content[0].title").value("REST API 모범 사례"))
+        .andExpect(jsonPath("$.content[0].createdAt").exists())
+        .andExpect(jsonPath("$.pagination.totalPages").value(1))
+        .andExpect(jsonPath("$.pagination.totalElements").value(1))
+        .andExpect(jsonPath("$.pagination.currentPage").value(1));
+        ;
     }
 
     @Test
-    void testGetNewExamList() throws Exception {
+    @DisplayName("출제 할 문제 목록 API 테스트")
+    void 출제_할_문제_목록_API_테스트() throws Exception {
         mockMvc.perform(get("/api/teacher/main/new-exam")
-            .param("memberSeq", "3")
-            .param("page", "0")
-            .param("size", "10")
-            .contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.content").isArray())
-            .andExpect(jsonPath("$.content[0].studentNickname").value("user2"))
-            .andExpect(jsonPath("$.content[0].title").value("new 시험"))
-            .andExpect(jsonPath("$.content[0].status").value("PREPARED")
-        );
+        .param("memberSeq", "3")
+        .param("page", "0")
+        .param("size", "10")
+        .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.content").isArray())
+        .andExpect(jsonPath("$.content[0].studentNickname").value("user2"))
+        .andExpect(jsonPath("$.content[0].title").value("new 시험"))
+        .andExpect(jsonPath("$.content[0].status").value("PREPARED"))
+        .andExpect(jsonPath("$.pagination.totalPages").value(1))
+        .andExpect(jsonPath("$.pagination.totalElements").value(1))
+        .andExpect(jsonPath("$.pagination.currentPage").value(1));
+    }
+
+    @Test
+    @DisplayName("출제 한 목록 조회 API 테스트")
+    void 출제_한_목록_조회_API_테스트() throws Exception {
+        mockMvc.perform(get("/api/teacher/main/authored-exam")
+        .param("memberSeq", "3")
+        .param("page", "0")
+        .param("size", "10")
+        .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.content").isArray())
+        .andExpect(jsonPath("$.content[0].studentNickname").value("user2"))
+        .andExpect(jsonPath("$.content[0].title").value("new 시험"))
+        .andExpect(jsonPath("$.content[0].status").value("FEEDBACK_COMPLETED"))
+        .andExpect(jsonPath("$.pagination.totalPages").value(1))
+        .andExpect(jsonPath("$.pagination.totalElements").value(1))
+        .andExpect(jsonPath("$.pagination.currentPage").value(1));
     }
 }

--- a/src/test/java/com/beelinkers/englebee/teacher/controller/api/TeacherMainApiControllerTest.java
+++ b/src/test/java/com/beelinkers/englebee/teacher/controller/api/TeacherMainApiControllerTest.java
@@ -15,7 +15,6 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.ResultActions;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -36,20 +35,17 @@ public class TeacherMainApiControllerTest {
 
     @MockBean
     private TeacherMainService teacherMainService;
-    private Page<TeacherMainPageLectureDTO> lecturePage;
-    private Page<TeacherMainPageQuestionDTO> questionPage;
 
     @BeforeEach
     void setUp() {
-        lecturePage = new PageImpl<>(List.of(new TeacherMainPageLectureDTO(
-                1L, "user3", "기초문법강의", "CREATED", // status
-                LocalDateTime.of(2024, 8, 23, 10, 0), // createdAt
-                List.of(List.of("어법", "중"), List.of("문장", "중"))
-            ))
+        Page<TeacherMainPageLectureDTO> lecturePage = new PageImpl<>(List.of(new TeacherMainPageLectureDTO(
+                1L, "user3", "기초문법강의", "CREATED",
+                LocalDateTime.now(), List.of(List.of("어법", "중"), List.of("문장", "중"))
+        ))
         );
-        questionPage = new PageImpl<>(List.of(new TeacherMainPageQuestionDTO(
+        Page<TeacherMainPageQuestionDTO> questionPage = new PageImpl<>(List.of(new TeacherMainPageQuestionDTO(
                 1L, "user2", "REST API 모범 사례", LocalDateTime.now()
-            ))
+        ))
         );
 
         Mockito.when(teacherMainService.getLectureList(anyLong(), any(Pageable.class)))
@@ -60,15 +56,16 @@ public class TeacherMainApiControllerTest {
 
     @Test
     void testGetLectureList() throws Exception {
-        ResultActions result = mockMvc.perform(get("/api/teacher/main/lecture")
+        mockMvc.perform(get("/api/teacher/main/lecture")
             .param("memberSeq", "3")
+            .param("page", "0")
             .param("size", "10")
             .contentType(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.content").isArray())
             .andExpect(jsonPath("$.content[0].title").value("기초문법강의"))
             .andExpect(jsonPath("$.content[0].status").value("CREATED"))
-            .andExpect(jsonPath("$.content[0].createdAt").value("2024-08-23T10:00:00"))
+            .andExpect(jsonPath("$.content[0].createdAt").exists())
             .andExpect(jsonPath("$.content[0].subjectLevelCode[0][0]").value("어법"))
             .andExpect(jsonPath("$.content[0].subjectLevelCode[0][1]").value("중"))
             .andExpect(jsonPath("$.pagination").exists())
@@ -80,7 +77,8 @@ public class TeacherMainApiControllerTest {
 
     @Test
     void testGetQuestionList() throws Exception {
-        ResultActions result = mockMvc.perform(get("/api/teacher/main/question")
+        mockMvc.perform(get("/api/teacher/main/question")
+            .param("page", "0")
             .param("size", "10")
             .contentType(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())

--- a/src/test/java/com/beelinkers/englebee/teacher/controller/api/TeacherMainApiControllerTest.java
+++ b/src/test/java/com/beelinkers/englebee/teacher/controller/api/TeacherMainApiControllerTest.java
@@ -1,0 +1,72 @@
+package com.beelinkers.englebee.teacher.controller.api;
+
+import com.beelinkers.englebee.teacher.dto.response.TeacherMainPageLectureDTO;
+import com.beelinkers.englebee.teacher.service.TeacherMainService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class TeacherMainApiControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private TeacherMainService teacherMainService;
+    private Page<TeacherMainPageLectureDTO> lecturePage;
+
+    @BeforeEach
+    void setUp() {
+        lecturePage = new PageImpl<>(List.of(new TeacherMainPageLectureDTO(
+                1L, "user3", "기초문법강의", "CREATED", // status
+                LocalDateTime.of(2024, 8, 23, 10, 0), // createdAt
+                List.of(List.of("어법", "중"), List.of("문장", "중"))
+            ))
+        );
+        Mockito.when(teacherMainService.getLectureList(anyLong(), any(Pageable.class)))
+                .thenReturn(lecturePage);
+    }
+
+    @Test
+    void testGetLectureList() throws Exception {
+        ResultActions result = mockMvc.perform(get("/api/teacher/main/lecture")
+            .param("memberSeq", "3")
+            .param("size", "10")
+            .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.content").isArray())
+            .andExpect(jsonPath("$.content[0].title").value("기초문법강의"))
+            .andExpect(jsonPath("$.content[0].status").value("CREATED"))
+            .andExpect(jsonPath("$.content[0].createdAt").value("2024-08-23T10:00:00"))
+            .andExpect(jsonPath("$.content[0].subjectLevelCode[0][0]").value("어법"))
+            .andExpect(jsonPath("$.content[0].subjectLevelCode[0][1]").value("중"))
+            .andExpect(jsonPath("$.pagination").exists())
+            .andExpect(jsonPath("$.pagination.totalPages").value(1))
+            .andExpect(jsonPath("$.pagination.totalElements").value(1))
+            .andExpect(jsonPath("$.pagination.currentPage").value(1)
+        );
+    }
+
+}

--- a/src/test/java/com/beelinkers/englebee/teacher/controller/api/TeacherMainApiControllerTest.java
+++ b/src/test/java/com/beelinkers/englebee/teacher/controller/api/TeacherMainApiControllerTest.java
@@ -1,6 +1,7 @@
 package com.beelinkers.englebee.teacher.controller.api;
 
 import com.beelinkers.englebee.teacher.dto.response.TeacherMainPageLectureDTO;
+import com.beelinkers.englebee.teacher.dto.response.TeacherMainPageQuestionDTO;
 import com.beelinkers.englebee.teacher.service.TeacherMainService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -36,6 +37,7 @@ public class TeacherMainApiControllerTest {
     @MockBean
     private TeacherMainService teacherMainService;
     private Page<TeacherMainPageLectureDTO> lecturePage;
+    private Page<TeacherMainPageQuestionDTO> questionPage;
 
     @BeforeEach
     void setUp() {
@@ -45,8 +47,15 @@ public class TeacherMainApiControllerTest {
                 List.of(List.of("어법", "중"), List.of("문장", "중"))
             ))
         );
+        questionPage = new PageImpl<>(List.of(new TeacherMainPageQuestionDTO(
+                1L, "user2", "REST API 모범 사례", LocalDateTime.now()
+            ))
+        );
+
         Mockito.when(teacherMainService.getLectureList(anyLong(), any(Pageable.class)))
                 .thenReturn(lecturePage);
+        Mockito.when(teacherMainService.getQuestionList(any(Pageable.class)))
+                .thenReturn(questionPage);
     }
 
     @Test
@@ -69,4 +78,17 @@ public class TeacherMainApiControllerTest {
         );
     }
 
+    @Test
+    void testGetQuestionList() throws Exception {
+        ResultActions result = mockMvc.perform(get("/api/teacher/main/question")
+            .param("size", "10")
+            .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.content").isArray())
+            .andExpect(jsonPath("$.content[0].memberNickname").value("user2"))
+            .andExpect(jsonPath("$.content[0].title").value("REST API 모범 사례"))
+            .andExpect(jsonPath("$.content[0].createdAt").exists())
+            .andExpect(jsonPath("$.pagination.currentPage").value(1)
+        );
+    }
 }

--- a/src/test/java/com/beelinkers/englebee/teacher/service/impl/TeacherMainServiceImplTest.java
+++ b/src/test/java/com/beelinkers/englebee/teacher/service/impl/TeacherMainServiceImplTest.java
@@ -1,0 +1,180 @@
+package com.beelinkers.englebee.teacher.service.impl;
+
+import com.beelinkers.englebee.auth.domain.entity.LoginType;
+import com.beelinkers.englebee.auth.domain.entity.Member;
+import com.beelinkers.englebee.auth.domain.entity.Role;
+import com.beelinkers.englebee.general.domain.entity.*;
+import com.beelinkers.englebee.general.domain.repository.ExamRepository;
+import com.beelinkers.englebee.general.domain.repository.LectureRepository;
+import com.beelinkers.englebee.general.domain.repository.QuestionRepository;
+import com.beelinkers.englebee.teacher.dto.response.TeacherMainPageAuthoredExamDTO;
+import com.beelinkers.englebee.teacher.dto.response.TeacherMainPageLectureDTO;
+import com.beelinkers.englebee.teacher.dto.response.TeacherMainPageNewExamDTO;
+import com.beelinkers.englebee.teacher.dto.response.TeacherMainPageQuestionDTO;
+import com.beelinkers.englebee.teacher.dto.response.mapper.TeacherMainPageMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class TeacherMainServiceImplTest {
+
+    @Mock
+    private TeacherMainPageMapper teacherMainPageMapper;
+
+    @Mock
+    private LectureRepository lectureRepository;
+
+    @Mock
+    private QuestionRepository questionRepository;
+
+    @Mock
+    private ExamRepository examRepository;
+
+    @InjectMocks
+    private TeacherMainServiceImpl teacherMainService;
+
+    @Test
+    void testGetLectureList() {
+        // Given
+        Long memberSeq = 3L;
+        PageRequest pageable = PageRequest.of(0, 10);
+
+        Member teacher = new Member("user3", "user3@example.com", Role.TEACHER, null, LoginType.GOOGLE, true);
+        Member student = new Member("user2", "user2@example.com", Role.STUDENT, null, LoginType.GOOGLE, true);
+
+        Lecture lecture = Lecture.builder()
+                .teacher(teacher)
+                .student(student)
+                .title("기초 문법 강의")
+                .build();
+
+        Page<Lecture> lecturePage = new PageImpl<>(List.of(lecture));
+        TeacherMainPageLectureDTO lectureDTO = new TeacherMainPageLectureDTO(
+                1L, "user2", "기초 문법 강의", "CREATED", LocalDateTime.now(), List.of()
+        );
+
+        when(lectureRepository.findByTeacherSeqAndStatus(anyLong(), eq(LectureStatus.CREATED), any(PageRequest.class)))
+                .thenReturn(lecturePage);
+        when(teacherMainPageMapper.teacherMainPageLectureDto(lecture)).thenReturn(lectureDTO);
+
+        // When
+        Page<TeacherMainPageLectureDTO> result = teacherMainService.getLectureList(memberSeq, pageable);
+
+        // Then
+        assertEquals(1, result.getTotalElements());
+        assertEquals(lectureDTO, result.getContent().get(0));
+    }
+
+    @Test
+    void testGetQuestionList() {
+        // Given
+        PageRequest pageable = PageRequest.of(0, 10);
+        Member member = new Member("user3", "user3@example.com", Role.TEACHER, null, LoginType.GOOGLE, true);
+        Question question = new Question(member, "What is Java?", "Detailed description");
+
+        Page<Question> questionPage = new PageImpl<>(List.of(question));
+        when(questionRepository.findAll(pageable)).thenReturn(questionPage);
+
+        TeacherMainPageQuestionDTO questionDTO = new TeacherMainPageQuestionDTO(
+                3L, "user3", "What is Java?", LocalDateTime.now()
+        );
+        when(teacherMainPageMapper.teacherMainPageQuestionDto(question)).thenReturn(questionDTO);
+
+        // When
+        Page<TeacherMainPageQuestionDTO> result = teacherMainService.getQuestionList(pageable);
+
+        // Then
+        assertEquals(1, result.getTotalElements());
+        assertEquals("user3", result.getContent().get(0).getMemberNickname());
+        assertEquals("What is Java?", result.getContent().get(0).getTitle());
+    }
+
+    @Test
+    void testGetNewExamList() {
+        // Given
+        Long memberSeq = 1L;
+        PageRequest pageable = PageRequest.of(0, 10);
+
+        Member teacher = new Member("teacher1", "teacher1@example.com", Role.TEACHER, null, LoginType.GOOGLE, true);
+        Member student = new Member("student1", "student1@example.com", Role.STUDENT, null, LoginType.GOOGLE, true);
+
+        Lecture lecture = Lecture.builder()
+                .teacher(teacher)
+                .student(student)
+                .title("Lecture 1")
+                .build();
+
+        Exam exam = Exam.builder()
+                .lecture(lecture)
+                .title("Exam 1")
+                .build();
+
+        Page<Exam> examPage = new PageImpl<>(List.of(exam));
+
+        TeacherMainPageNewExamDTO newExamDTO = new TeacherMainPageNewExamDTO(
+                1L, 1L, "user2", "Exam 1", "CREATED"
+        );
+
+        when(examRepository.findByLectureTeacherSeqAndStatus(memberSeq, ExamStatus.CREATED, pageable))
+                .thenReturn(examPage);
+        when(teacherMainPageMapper.teacherMainPageNewExamDto(exam)).thenReturn(newExamDTO);
+
+        // When
+        Page<TeacherMainPageNewExamDTO> result = teacherMainService.getNewExamList(memberSeq, pageable);
+
+        // Then
+        assertEquals(1, result.getTotalElements());
+        assertEquals(newExamDTO, result.getContent().get(0));
+    }
+
+    @Test
+    void testGetAuthoredExamList() {
+        // Given
+        Long memberSeq = 1L;
+        PageRequest pageable = PageRequest.of(0, 10);
+
+        Member teacher = new Member("user6", "user3@example.com", Role.TEACHER, null, LoginType.GOOGLE, true);
+        Member student = new Member("user4", "user2@example.com", Role.STUDENT, null, LoginType.GOOGLE, true);
+
+        Lecture lecture = Lecture.builder()
+                .teacher(teacher)
+                .student(student)
+                .title("Lecture 1")
+                .build();
+
+        Exam exam = Exam.builder()
+                .lecture(lecture)
+                .title("Exam 1")
+                .build();
+
+        Page<Exam> examPage = new PageImpl<>(List.of(exam));
+
+        TeacherMainPageAuthoredExamDTO authoredExamDTO = new TeacherMainPageAuthoredExamDTO(
+                1L, 1L, "student1", "Authored Exam", "SUBMITTED"
+        );
+
+        when(examRepository.findByLectureTeacherSeqAndStatusNot(memberSeq, ExamStatus.CREATED, pageable))
+                .thenReturn(examPage);
+        when(teacherMainPageMapper.teacherMainPageAuthoredExamDTO(exam)).thenReturn(authoredExamDTO);
+
+        // When
+        Page<TeacherMainPageAuthoredExamDTO> result = teacherMainService.getAuthoredExamList(memberSeq, pageable);
+
+        // Then
+        assertEquals(1, result.getTotalElements());
+        assertEquals(authoredExamDTO, result.getContent().get(0));
+    }
+}

--- a/src/test/java/com/beelinkers/englebee/teacher/service/impl/TeacherMainServiceImplTest.java
+++ b/src/test/java/com/beelinkers/englebee/teacher/service/impl/TeacherMainServiceImplTest.java
@@ -12,6 +12,7 @@ import com.beelinkers.englebee.teacher.dto.response.TeacherMainPageLectureDTO;
 import com.beelinkers.englebee.teacher.dto.response.TeacherMainPageNewExamDTO;
 import com.beelinkers.englebee.teacher.dto.response.TeacherMainPageQuestionDTO;
 import com.beelinkers.englebee.teacher.dto.response.mapper.TeacherMainPageMapper;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -48,7 +49,8 @@ public class TeacherMainServiceImplTest {
     private TeacherMainServiceImpl teacherMainService;
 
     @Test
-    void testGetLectureList() {
+    @DisplayName("수업 목록을 조회할 수 있다")
+    void 수업_목록을_조회할_수_있다() {
         // Given
         Long memberSeq = 3L;
         PageRequest pageable = PageRequest.of(0, 10);
@@ -80,7 +82,8 @@ public class TeacherMainServiceImplTest {
     }
 
     @Test
-    void testGetQuestionList() {
+    @DisplayName("질문 목록을 조회할 수 있다.")
+    void 질문_목록을_조회할_수_있다() {
         // Given
         PageRequest pageable = PageRequest.of(0, 10);
         Member member = new Member("user3", "user3@example.com", Role.TEACHER, null, LoginType.GOOGLE, true);
@@ -104,7 +107,8 @@ public class TeacherMainServiceImplTest {
     }
 
     @Test
-    void testGetNewExamList() {
+    @DisplayName("출제할 시험 목록을 조회할 수 있다. ")
+    void 출제할_시험_목록을_조회할_수_있다() {
         // Given
         Long memberSeq = 1L;
         PageRequest pageable = PageRequest.of(0, 10);
@@ -142,7 +146,8 @@ public class TeacherMainServiceImplTest {
     }
 
     @Test
-    void testGetAuthoredExamList() {
+    @DisplayName("출제한 시험을 조회할 수 있다.")
+    void 출제한_시험을_조회할_수_있다() {
         // Given
         Long memberSeq = 1L;
         PageRequest pageable = PageRequest.of(0, 10);

--- a/src/test/java/com/beelinkers/englebee/teacher/service/impl/TeacherMainServiceImplTest.java
+++ b/src/test/java/com/beelinkers/englebee/teacher/service/impl/TeacherMainServiceImplTest.java
@@ -13,13 +13,13 @@ import com.beelinkers.englebee.teacher.dto.response.TeacherMainPageNewExamDTO;
 import com.beelinkers.englebee.teacher.dto.response.TeacherMainPageQuestionDTO;
 import com.beelinkers.englebee.teacher.dto.response.mapper.TeacherMainPageMapper;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -28,7 +28,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.when;
 
-@ExtendWith(MockitoExtension.class)
+@SpringBootTest
+@Transactional
 public class TeacherMainServiceImplTest {
 
     @Mock


### PR DESCRIPTION
## 👀 관련 이슈

close #9

## ✨ 작업 내용

<!-- 이번 PR에서 작업한 내용을 리스트 형식으로 작성해주세요. (이미지 첨부 가능) -->

- 진행 중인 강의를 확인할 수 있다.
- Q&A 목록을 조회할 수 있다.
- 강의 종료 후 출제할 시험 리스트를 조회할 수 있다.
- 출제 했던 시험 리스트를 조회할 수 있다.
- 리스트 페이지네이션 처리
- Test Code 작성

## 📸 스크린샷

<!-- (선택) 작업 내용을 설명할 수 있는 관련 화면을 스크린샷으로 남겨주세요. (없는 경우 '없음'이라 작성해주세요.) -->

- 없음

## 🙏 리뷰 요구 사항

<!-- 리뷰어가 특별히 봐주었으면 하는 부분을 알려주세요. -->

- 없음

## 📢 논의하고 싶은 내용

<!-- (선택) 논의하고 싶은 내용 작성해주세요.
ex) 메서드 xxx의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? 
(없는 경우 '없음'이라 작성해주세요.) -->

- 없음

## 🎸 기타 사항

<!-- (선택) 다른 개발자분들이 인지해놓는다면 좋은 내용들이나 특이사항이 있다면 남겨주세요. 
(없는 경우 '없음'이라 작성해주세요.)-->

- 없음