### PR TITLE
[feat-infra-session-db-setting] 운영환경에서 세션을 DB에 저장하도록 하는 의존성 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
+    implementation 'org.springframework.session:spring-session-jdbc'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     implementation 'org.mariadb.jdbc:mariadb-java-client:3.0.3'


### PR DESCRIPTION
## 👀 관련 이슈

close #25 

## ✨ 작업 내용

<!-- 이번 PR에서 작업한 내용을 리스트 형식으로 작성해주세요. (이미지 첨부 가능) -->

- 세션을 DB에서 관리하도록 설정하는 의존성을 추가했습니다.
- 해당 의존성이 자동 생성해주는 테이블 ( 세션 테이블 )을 운영 환경에서 적용하기 위해 RDS 내부에서 세션 테이블을 생성해주었습니다.
( 운영 환경의 profile에는 ddl-auto = none 으로 설정되어 있기에, 직접 추가해주었습니다. )

## 📸 스크린샷

<!-- (선택) 작업 내용을 설명할 수 있는 관련 화면을 스크린샷으로 남겨주세요. (없는 경우 '없음'이라 작성해주세요.) -->

- 아래 사진은 RDS 내부에서 세션 테이블을 생성하는 DDL문입니다.

<img width="1215" alt="스크린샷 2024-08-30 오후 12 28 06" src="https://github.com/user-attachments/assets/0f31349d-68ab-4f16-978f-494f9d9cb559">


## 🙏 리뷰 요구 사항

<!-- 리뷰어가 특별히 봐주었으면 하는 부분을 알려주세요. -->

없음

## 📢 논의하고 싶은 내용

<!-- (선택) 논의하고 싶은 내용 작성해주세요.
ex) 메서드 xxx의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? 
(없는 경우 '없음'이라 작성해주세요.) -->

없음

## 🎸 기타 사항

<!-- (선택) 다른 개발자분들이 인지해놓는다면 좋은 내용들이나 특이사항이 있다면 남겨주세요. 
(없는 경우 '없음'이라 작성해주세요.)-->

없음