### PR TITLE
[fix-teacher-exam-register-and-feedback] 선생님 시험 등록 페이지, 시험 피드백 페이지에 학생의 학년을 model에 반환하는 기능 추가

### DIFF
--- a/src/main/java/com/beelinkers/englebee/teacher/controller/page/TeacherExamPageController.java
+++ b/src/main/java/com/beelinkers/englebee/teacher/controller/page/TeacherExamPageController.java
@@ -25,6 +25,7 @@ public class TeacherExamPageController {
     TeacherExamRegisterPageDTO teacherExamRegisterPageInfo = teacherExamPageService.getTeacherExamRegisterPageInfo(
         sessionMember.getSeq(), examSeq);
     model.addAttribute("examSeq", examSeq);
+    model.addAttribute("studentGrade", teacherExamRegisterPageInfo.getStudentGrade());
     model.addAttribute("studentSubjectLevels",
         teacherExamRegisterPageInfo.getStudentSubjectLevels());
     model.addAttribute("lecture6SubjectLevels",
@@ -38,6 +39,7 @@ public class TeacherExamPageController {
     TeacherExamFeedbackPageDTO teacherExamFeedbackPageDTO = teacherExamPageService.getTeacherExamFeedbackPageInfo(
         sessionMember.getSeq(), examSeq);
     model.addAttribute("examSeq", examSeq);
+    model.addAttribute("studentGrade", teacherExamFeedbackPageDTO.getStudentGrade());
     model.addAttribute("examTitle", teacherExamFeedbackPageDTO.getExamTitle());
     model.addAttribute("teacherQuestions",
         teacherExamFeedbackPageDTO.getTeacherQuestionForTeacherToFeedbackDTOs());

--- a/src/main/java/com/beelinkers/englebee/teacher/dto/response/TeacherExamFeedbackPageDTO.java
+++ b/src/main/java/com/beelinkers/englebee/teacher/dto/response/TeacherExamFeedbackPageDTO.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public class TeacherExamFeedbackPageDTO {
 
+  private String studentGrade;
   private String examTitle;
   private List<TeacherQuestionForTeacherToFeedbackDTO> teacherQuestionForTeacherToFeedbackDTOs;
 

--- a/src/main/java/com/beelinkers/englebee/teacher/dto/response/TeacherExamRegisterPageDTO.java
+++ b/src/main/java/com/beelinkers/englebee/teacher/dto/response/TeacherExamRegisterPageDTO.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public class TeacherExamRegisterPageDTO {
 
+  private String studentGrade;
   private Map<String, String> lectureSubjectLevels;
   private Map<String, String> studentSubjectLevels;
 

--- a/src/main/java/com/beelinkers/englebee/teacher/dto/response/mapper/TeacherExamFeedbackPageMapper.java
+++ b/src/main/java/com/beelinkers/englebee/teacher/dto/response/mapper/TeacherExamFeedbackPageMapper.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class TeacherExamFeedbackPageMapper {
 
-  public TeacherExamFeedbackPageDTO toExamFeedbackPageDTO(String examTitle,
+  public TeacherExamFeedbackPageDTO toExamFeedbackPageDTO(String studentGrade, String examTitle,
       List<TeacherQuestion> teacherQuestions) {
     List<TeacherQuestionForTeacherToFeedbackDTO> teacherQuestionForStudentToSolveDTOs = teacherQuestions.stream()
         .map(tq -> new TeacherQuestionForTeacherToFeedbackDTO(
@@ -22,6 +22,7 @@ public class TeacherExamFeedbackPageMapper {
             tq.getStudentAnswer(),
             tq.getIntent()))
         .toList();
-    return new TeacherExamFeedbackPageDTO(examTitle, teacherQuestionForStudentToSolveDTOs);
+    return new TeacherExamFeedbackPageDTO(studentGrade, examTitle,
+        teacherQuestionForStudentToSolveDTOs);
   }
 }

--- a/src/main/java/com/beelinkers/englebee/teacher/dto/response/mapper/TeacherExamRegisterPageMapper.java
+++ b/src/main/java/com/beelinkers/englebee/teacher/dto/response/mapper/TeacherExamRegisterPageMapper.java
@@ -7,8 +7,9 @@ import org.springframework.stereotype.Component;
 @Component
 public class TeacherExamRegisterPageMapper {
 
-  public TeacherExamRegisterPageDTO toExamRegisterPageDTO(Map<String, String> lectureSubjectLevels,
+  public TeacherExamRegisterPageDTO toExamRegisterPageDTO(String studentGrade,
+      Map<String, String> lectureSubjectLevels,
       Map<String, String> studentSubjectLevels) {
-    return new TeacherExamRegisterPageDTO(studentSubjectLevels, lectureSubjectLevels);
+    return new TeacherExamRegisterPageDTO(studentGrade, studentSubjectLevels, lectureSubjectLevels);
   }
 }

--- a/src/main/java/com/beelinkers/englebee/teacher/service/impl/TeacherExamPageServiceImpl.java
+++ b/src/main/java/com/beelinkers/englebee/teacher/service/impl/TeacherExamPageServiceImpl.java
@@ -43,9 +43,12 @@ public class TeacherExamPageServiceImpl implements TeacherExamPageService {
     Member teacher = validateAndGetTeacher(teacherSeq);
     Exam exam = validateExamAndCheckIsPreparedForRegistration(teacher, examSeq);
     Lecture lecture = exam.getLecture();
+    Member student = lecture.getStudent();
+    String studentGrade = student.getGrade().getKoreanGrade();
     Map<String, String> lectureSubjectLevels = extractLectureSubjectLevels(lecture);
-    Map<String, String> studentSubjectLevels = extractStudentSubjectLevels(lecture.getStudent());
-    return mapToTeacherExamRegisterPageDTO(lectureSubjectLevels, studentSubjectLevels);
+    Map<String, String> studentSubjectLevels = extractStudentSubjectLevels(student);
+    return mapToTeacherExamRegisterPageDTO(studentGrade, lectureSubjectLevels,
+        studentSubjectLevels);
   }
 
   @Override
@@ -99,9 +102,9 @@ public class TeacherExamPageServiceImpl implements TeacherExamPageService {
     return studentSubjectLevelsMap;
   }
 
-  private TeacherExamRegisterPageDTO mapToTeacherExamRegisterPageDTO(
+  private TeacherExamRegisterPageDTO mapToTeacherExamRegisterPageDTO(String studentGrade,
       Map<String, String> lectureSubjectLevels, Map<String, String> studentSubjectLevels) {
-    return teacherExamRegisterPageMapper.toExamRegisterPageDTO(lectureSubjectLevels,
+    return teacherExamRegisterPageMapper.toExamRegisterPageDTO(studentGrade, lectureSubjectLevels,
         studentSubjectLevels);
   }
 
@@ -114,7 +117,9 @@ public class TeacherExamPageServiceImpl implements TeacherExamPageService {
 
   private TeacherExamFeedbackPageDTO mapToTeacherExamFeedbackPageDTO(Exam exam) {
     List<TeacherQuestion> teacherQuestions = teacherQuestionRepository.findByExam(exam);
-    return teacherExamFeedbackPageMapper.toExamFeedbackPageDTO(exam.getTitle(), teacherQuestions);
+    return teacherExamFeedbackPageMapper.toExamFeedbackPageDTO(
+        exam.getLecture().getStudent().getGrade().getKoreanGrade(), exam.getTitle(),
+        teacherQuestions);
   }
 
 }


### PR DESCRIPTION
## 👀 관련 이슈

close #이슈번호

## ✨ 작업 내용

<!-- 이번 PR에서 작업한 내용을 리스트 형식으로 작성해주세요. (이미지 첨부 가능) -->

- 선생님 시험 등록 페이지, 시험 피드백 페이지에 학생의 학년을 model에 반환하는 기능 추가하였습니다.

## 📸 스크린샷

<!-- (선택) 작업 내용을 설명할 수 있는 관련 화면을 스크린샷으로 남겨주세요. (없는 경우 '없음'이라 작성해주세요.) -->

- 없음

## 🙏 리뷰 요구 사항

<!-- 리뷰어가 특별히 봐주었으면 하는 부분을 알려주세요. -->

- 없음

## 📢 논의하고 싶은 내용

<!-- (선택) 논의하고 싶은 내용 작성해주세요.
ex) 메서드 xxx의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? 
(없는 경우 '없음'이라 작성해주세요.) -->

- 없음

## 🎸 기타 사항

<!-- (선택) 다른 개발자분들이 인지해놓는다면 좋은 내용들이나 특이사항이 있다면 남겨주세요. 
(없는 경우 '없음'이라 작성해주세요.)-->

- 없음