### PR TITLE
[feat-auth-oauth2-signup-in-production-all] 네이버,구글 회원가입/로그인, 추가회원가입, 로그아웃, 회원탈퇴 API와 뷰 연동 | 인증, 인가 관련 뷰 수정

### DIFF
--- a/src/main/java/com/beelinkers/englebee/auth/argumentresolver/SignupProgressMemberArgumentResolver.java
+++ b/src/main/java/com/beelinkers/englebee/auth/argumentresolver/SignupProgressMemberArgumentResolver.java
@@ -29,6 +29,8 @@ public class SignupProgressMemberArgumentResolver implements HandlerMethodArgume
   public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
       NativeWebRequest webRequest,
       WebDataBinderFactory binderFactory) {
+    SignupProgressSessionMember value = (SignupProgressSessionMember) httpSession.getAttribute(
+        SIGNUP_PROGRESS_SESSION_MEMBER_KEY);
     return httpSession.getAttribute(SIGNUP_PROGRESS_SESSION_MEMBER_KEY);
   }
 }

--- a/src/main/java/com/beelinkers/englebee/auth/argumentresolver/SignupProgressMemberArgumentResolver.java
+++ b/src/main/java/com/beelinkers/englebee/auth/argumentresolver/SignupProgressMemberArgumentResolver.java
@@ -29,8 +29,6 @@ public class SignupProgressMemberArgumentResolver implements HandlerMethodArgume
   public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
       NativeWebRequest webRequest,
       WebDataBinderFactory binderFactory) {
-    SignupProgressSessionMember value = (SignupProgressSessionMember) httpSession.getAttribute(
-        SIGNUP_PROGRESS_SESSION_MEMBER_KEY);
     return httpSession.getAttribute(SIGNUP_PROGRESS_SESSION_MEMBER_KEY);
   }
 }

--- a/src/main/java/com/beelinkers/englebee/auth/config/SecurityConfig.java
+++ b/src/main/java/com/beelinkers/englebee/auth/config/SecurityConfig.java
@@ -26,8 +26,7 @@ public class SecurityConfig {
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 
     http
-        .csrf(csrf -> csrf
-            .ignoringRequestMatchers("/h2-console/**"))
+        .csrf(AbstractHttpConfigurer::disable)
         .headers(headers -> headers
             .frameOptions(FrameOptionsConfig::sameOrigin));
 

--- a/src/main/java/com/beelinkers/englebee/auth/config/SecurityConfig.java
+++ b/src/main/java/com/beelinkers/englebee/auth/config/SecurityConfig.java
@@ -55,7 +55,7 @@ public class SecurityConfig {
     http
         .authorizeHttpRequests(auth -> auth
             .requestMatchers("/", "/oauth2/**", "/login/**", "/h2-console/**", "/api/auth/**",
-                "/main", "/signup", "/api/auth/signup/**").permitAll()
+                "/main", "/signup").permitAll()
             .requestMatchers("/chat", "/socket")
             .hasAnyRole(Role.TEACHER.name(), Role.STUDENT.name())
             .requestMatchers("/api/admin/**").hasRole(Role.ADMIN.name())

--- a/src/main/java/com/beelinkers/englebee/auth/config/SecurityConfig.java
+++ b/src/main/java/com/beelinkers/englebee/auth/config/SecurityConfig.java
@@ -63,6 +63,8 @@ public class SecurityConfig {
             .requestMatchers("/api/student/**").hasRole(Role.STUDENT.name())
             .requestMatchers("/api/auth/account/deactivate")
             .hasAnyRole(Role.STUDENT.name(), Role.TEACHER.name())
+            .requestMatchers("/my/**", "/qna/**", "/exam/**")
+            .hasAnyRole(Role.STUDENT.name(), Role.TEACHER.name())
             .requestMatchers("/static/**", "/assets/**", "/css/**", "/js/**", "/images/**")
             .permitAll() // 정적 자원 허용
             .anyRequest().authenticated());

--- a/src/main/java/com/beelinkers/englebee/auth/controller/api/AuthApiController.java
+++ b/src/main/java/com/beelinkers/englebee/auth/controller/api/AuthApiController.java
@@ -3,7 +3,6 @@ package com.beelinkers.englebee.auth.controller.api;
 import static com.beelinkers.englebee.auth.constant.AuthConstant.SESSION_MEMBER_KEY;
 import static com.beelinkers.englebee.auth.constant.AuthConstant.SIGNUP_PROGRESS_SESSION_MEMBER_KEY;
 
-import com.beelinkers.englebee.auth.annotation.LoginMember;
 import com.beelinkers.englebee.auth.annotation.SignupProgressMember;
 import com.beelinkers.englebee.auth.domain.entity.Member;
 import com.beelinkers.englebee.auth.dto.request.StudentSignupRequestDTO;
@@ -67,14 +66,6 @@ public class AuthApiController {
     Member member = authService.signupTeacher(signupProgressSessionMember, teacherSignupRequestDTO);
     makeMemberSession(httpSession, member);
     return ResponseEntity.status(HttpStatus.CREATED).build();
-  }
-
-  @PostMapping("/account/deactivate")
-  public ResponseEntity<Void> deactivate(@LoginMember SessionMember sessionMember,
-      HttpSession httpSession) {
-    authService.deactivateAccount(sessionMember.getSeq());
-    httpSession.invalidate();
-    return ResponseEntity.noContent().build();
   }
 
   private void checkSignupProgressMemberSessionExist(

--- a/src/main/java/com/beelinkers/englebee/auth/controller/api/AuthApiController.java
+++ b/src/main/java/com/beelinkers/englebee/auth/controller/api/AuthApiController.java
@@ -35,15 +35,13 @@ public class AuthApiController {
   private final GeneralMemberService generalMemberService;
 
   @PostMapping("/nickname-duplicated")
-  public ResponseEntity<Boolean> checkNicknameIsDuplicated(
+  public ResponseEntity<Void> checkNicknameIsDuplicated(
       @SignupProgressMember SignupProgressSessionMember signupProgressSessionMember,
       @RequestParam String nickname) {
     checkSignupProgressMemberSessionExist(signupProgressSessionMember);
-    if (nickname.length() > 20 || nickname.isEmpty()) {
-      throw new MemberNicknameLengthException("닉네임의 길이는 1글자 ~ 20글자 사이여야 합니다.");
-    }
-    return ResponseEntity.ok()
-        .body(generalMemberService.checkNicknameDuplicated(nickname));
+    checkNicknameLength(nickname);
+    generalMemberService.checkNicknameDuplicated(nickname);
+    return ResponseEntity.ok().build();
   }
 
   @PostMapping("/signup/student")
@@ -72,6 +70,12 @@ public class AuthApiController {
       SignupProgressSessionMember signupProgressSessionMember) {
     if (signupProgressSessionMember == null) {
       throw new SignupProgressSessionNotFoundException("잘못된 회원가입 요청입니다.");
+    }
+  }
+
+  private void checkNicknameLength(String nickname) {
+    if (nickname.length() > 20 || nickname.isEmpty()) {
+      throw new MemberNicknameLengthException("닉네임의 길이는 1글자 ~ 20글자 사이여야 합니다.");
     }
   }
 

--- a/src/main/java/com/beelinkers/englebee/auth/controller/api/AuthApiController.java
+++ b/src/main/java/com/beelinkers/englebee/auth/controller/api/AuthApiController.java
@@ -35,8 +35,6 @@ public class AuthApiController {
   public ResponseEntity<Void> checkNicknameIsDuplicated(
       @SignupProgressMember SignupProgressSessionMember signupProgressSessionMember,
       @RequestBody @Valid NicknameCheckRequestDTO nicknameCheckRequestDTO) {
-    log.info("하이 닉네임 " + signupProgressSessionMember.getEmail());
-    log.info("하이 로그인타입 " + signupProgressSessionMember.getLoginType());
     checkSignupProgressMemberSessionExist(signupProgressSessionMember);
     generalMemberService.checkNicknameDuplicated(nicknameCheckRequestDTO.getNickname());
     return ResponseEntity.ok().build();
@@ -47,8 +45,6 @@ public class AuthApiController {
       @SignupProgressMember SignupProgressSessionMember signupProgressSessionMember,
       @RequestBody @Valid StudentSignupRequestDTO studentSignupRequestDTO,
       HttpSession httpSession) {
-    log.info("하이 회원가입 닉네임 " + signupProgressSessionMember.getEmail());
-    log.info("하이 회원가입 로그인타입 " + signupProgressSessionMember.getLoginType());
     checkSignupProgressMemberSessionExist(signupProgressSessionMember);
     Member member = authService.signupStudent(signupProgressSessionMember, studentSignupRequestDTO);
     deleteSignupProgressMemberSession(httpSession, member);

--- a/src/main/java/com/beelinkers/englebee/auth/controller/api/AuthApiController.java
+++ b/src/main/java/com/beelinkers/englebee/auth/controller/api/AuthApiController.java
@@ -5,13 +5,13 @@ import static com.beelinkers.englebee.auth.constant.AuthConstant.SIGNUP_PROGRESS
 
 import com.beelinkers.englebee.auth.annotation.SignupProgressMember;
 import com.beelinkers.englebee.auth.domain.entity.Member;
+import com.beelinkers.englebee.auth.dto.request.NicknameCheckRequestDTO;
 import com.beelinkers.englebee.auth.dto.request.StudentSignupRequestDTO;
 import com.beelinkers.englebee.auth.dto.request.TeacherSignupRequestDTO;
 import com.beelinkers.englebee.auth.exception.SignupProgressSessionNotFoundException;
 import com.beelinkers.englebee.auth.oauth2.session.SessionMember;
 import com.beelinkers.englebee.auth.oauth2.session.SignupProgressSessionMember;
 import com.beelinkers.englebee.auth.service.AuthService;
-import com.beelinkers.englebee.general.exception.MemberNicknameLengthException;
 import com.beelinkers.englebee.general.service.GeneralMemberService;
 import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
@@ -22,7 +22,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
@@ -37,10 +36,9 @@ public class AuthApiController {
   @PostMapping("/nickname-duplicated")
   public ResponseEntity<Void> checkNicknameIsDuplicated(
       @SignupProgressMember SignupProgressSessionMember signupProgressSessionMember,
-      @RequestParam String nickname) {
+      @RequestBody @Valid NicknameCheckRequestDTO nicknameCheckRequestDTO) {
     checkSignupProgressMemberSessionExist(signupProgressSessionMember);
-    checkNicknameLength(nickname);
-    generalMemberService.checkNicknameDuplicated(nickname);
+    generalMemberService.checkNicknameDuplicated(nicknameCheckRequestDTO.getNickname());
     return ResponseEntity.ok().build();
   }
 
@@ -70,12 +68,6 @@ public class AuthApiController {
       SignupProgressSessionMember signupProgressSessionMember) {
     if (signupProgressSessionMember == null) {
       throw new SignupProgressSessionNotFoundException("잘못된 회원가입 요청입니다.");
-    }
-  }
-
-  private void checkNicknameLength(String nickname) {
-    if (nickname.length() > 20 || nickname.isEmpty()) {
-      throw new MemberNicknameLengthException("닉네임의 길이는 1글자 ~ 20글자 사이여야 합니다.");
     }
   }
 

--- a/src/main/java/com/beelinkers/englebee/auth/controller/api/AuthApiController.java
+++ b/src/main/java/com/beelinkers/englebee/auth/controller/api/AuthApiController.java
@@ -1,6 +1,5 @@
 package com.beelinkers.englebee.auth.controller.api;
 
-import static com.beelinkers.englebee.auth.constant.AuthConstant.SESSION_MEMBER_KEY;
 import static com.beelinkers.englebee.auth.constant.AuthConstant.SIGNUP_PROGRESS_SESSION_MEMBER_KEY;
 
 import com.beelinkers.englebee.auth.annotation.SignupProgressMember;
@@ -9,7 +8,6 @@ import com.beelinkers.englebee.auth.dto.request.NicknameCheckRequestDTO;
 import com.beelinkers.englebee.auth.dto.request.StudentSignupRequestDTO;
 import com.beelinkers.englebee.auth.dto.request.TeacherSignupRequestDTO;
 import com.beelinkers.englebee.auth.exception.SignupProgressSessionNotFoundException;
-import com.beelinkers.englebee.auth.oauth2.session.SessionMember;
 import com.beelinkers.englebee.auth.oauth2.session.SignupProgressSessionMember;
 import com.beelinkers.englebee.auth.service.AuthService;
 import com.beelinkers.englebee.general.service.GeneralMemberService;
@@ -53,7 +51,7 @@ public class AuthApiController {
     log.info("하이 회원가입 로그인타입 " + signupProgressSessionMember.getLoginType());
     checkSignupProgressMemberSessionExist(signupProgressSessionMember);
     Member member = authService.signupStudent(signupProgressSessionMember, studentSignupRequestDTO);
-    makeMemberSession(httpSession, member);
+    deleteSignupProgressMemberSession(httpSession, member);
     return ResponseEntity.status(HttpStatus.CREATED).build();
   }
 
@@ -64,7 +62,7 @@ public class AuthApiController {
       HttpSession httpSession) {
     checkSignupProgressMemberSessionExist(signupProgressSessionMember);
     Member member = authService.signupTeacher(signupProgressSessionMember, teacherSignupRequestDTO);
-    makeMemberSession(httpSession, member);
+    deleteSignupProgressMemberSession(httpSession, member);
     return ResponseEntity.status(HttpStatus.CREATED).build();
   }
 
@@ -75,10 +73,9 @@ public class AuthApiController {
     }
   }
 
-  private void makeMemberSession(HttpSession httpSession, Member member) {
+  private void deleteSignupProgressMemberSession(HttpSession httpSession, Member member) {
     httpSession.removeAttribute(SIGNUP_PROGRESS_SESSION_MEMBER_KEY);
-    httpSession.setAttribute(SESSION_MEMBER_KEY,
-        new SessionMember(member.getSeq(), member.getRole()));
+
   }
 
 }

--- a/src/main/java/com/beelinkers/englebee/auth/controller/api/AuthApiController.java
+++ b/src/main/java/com/beelinkers/englebee/auth/controller/api/AuthApiController.java
@@ -37,6 +37,8 @@ public class AuthApiController {
   public ResponseEntity<Void> checkNicknameIsDuplicated(
       @SignupProgressMember SignupProgressSessionMember signupProgressSessionMember,
       @RequestBody @Valid NicknameCheckRequestDTO nicknameCheckRequestDTO) {
+    log.info("하이 닉네임 " + signupProgressSessionMember.getEmail());
+    log.info("하이 로그인타입 " + signupProgressSessionMember.getLoginType());
     checkSignupProgressMemberSessionExist(signupProgressSessionMember);
     generalMemberService.checkNicknameDuplicated(nicknameCheckRequestDTO.getNickname());
     return ResponseEntity.ok().build();
@@ -47,6 +49,8 @@ public class AuthApiController {
       @SignupProgressMember SignupProgressSessionMember signupProgressSessionMember,
       @RequestBody @Valid StudentSignupRequestDTO studentSignupRequestDTO,
       HttpSession httpSession) {
+    log.info("하이 회원가입 닉네임 " + signupProgressSessionMember.getEmail());
+    log.info("하이 회원가입 로그인타입 " + signupProgressSessionMember.getLoginType());
     checkSignupProgressMemberSessionExist(signupProgressSessionMember);
     Member member = authService.signupStudent(signupProgressSessionMember, studentSignupRequestDTO);
     makeMemberSession(httpSession, member);

--- a/src/main/java/com/beelinkers/englebee/auth/controller/page/SignupProgressPageController.java
+++ b/src/main/java/com/beelinkers/englebee/auth/controller/page/SignupProgressPageController.java
@@ -14,7 +14,7 @@ public class SignupProgressPageController {
   public String getSignupProgressPage(
       @SignupProgressMember SignupProgressSessionMember signupProgressSessionMember) {
     if (signupProgressSessionMember == null) {
-      return "index";
+      return "redirect:/index";
     }
     return "auth/signup-progress";
   }

--- a/src/main/java/com/beelinkers/englebee/auth/dto/request/NicknameCheckRequestDTO.java
+++ b/src/main/java/com/beelinkers/englebee/auth/dto/request/NicknameCheckRequestDTO.java
@@ -1,0 +1,19 @@
+package com.beelinkers.englebee.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Length;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class NicknameCheckRequestDTO {
+
+  @NotNull(message = "닉네임 입력값이 존재하지 않습니다.")
+  @NotBlank(message = "닉네임 값은 비어있으면 안됩니다.")
+  @Length(min = 1, max = 20, message = "닉네임의 길이는 1글자 ~ 20글자 사이여야 합니다.")
+  private String nickname;
+}

--- a/src/main/java/com/beelinkers/englebee/auth/oauth2/exception/DeactivatedMemberException.java
+++ b/src/main/java/com/beelinkers/englebee/auth/oauth2/exception/DeactivatedMemberException.java
@@ -1,0 +1,10 @@
+package com.beelinkers.englebee.auth.oauth2.exception;
+
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+
+public class DeactivatedMemberException extends OAuth2AuthenticationException {
+
+  public DeactivatedMemberException(String msg) {
+    super(msg);
+  }
+}

--- a/src/main/java/com/beelinkers/englebee/auth/oauth2/exception/handler/CustomAuthenticationFailureHandler.java
+++ b/src/main/java/com/beelinkers/englebee/auth/oauth2/exception/handler/CustomAuthenticationFailureHandler.java
@@ -19,24 +19,43 @@ public class CustomAuthenticationFailureHandler implements AuthenticationFailure
   public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
       AuthenticationException exception) throws IOException, ServletException {
 
+    response.setCharacterEncoding("UTF-8");
+    response.setContentType("text/html; charset=UTF-8");
+
+    String errorMessage;
+    String redirectUrl = "/main"; // 기본 리다이렉트 URL
+
     if (exception instanceof SignupRequiredException) {
       // 추가회원가입 필요시 이동 처리
-      response.sendRedirect("/signup");
+      errorMessage = "추가회원가입 페이지로 이동합니다.";
+      redirectUrl = "/signup"; // 회원가입 페이지로 리다이렉트
     } else if (exception instanceof UnsupportedSocialLoginTypeException) {
       // 구글, 네이버 이외의 소셜 로그인 타입
-      response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
-      response.getWriter().write(exception.getMessage());
+      errorMessage = "해당 소셜 로그인 타입은 지원하지 않습니다.";
     } else if (exception instanceof AlreadySignedUpEmailException) {
       // 이미 다른 소셜 로그인 타입으로 회원가입 완료된 경우
-      response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
-      response.getWriter().write(exception.getMessage());
+      errorMessage = "이미 다른 소셜로그인 계정으로 가입된 이메일입니다. 해당 소셜 로그인 계정으로 로그인해주세요.";
     } else if (exception instanceof DeactivatedMemberException) {
       // 회원탈퇴 처리된 계정인 경우
-      response.setStatus(HttpServletResponse.SC_FORBIDDEN);
-      response.getWriter().write(exception.getMessage());
+      errorMessage = "회원 탈퇴 처리된 계정입니다.";
     } else {
-      // 그 밖 예외 처리
-      response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "인증에 실패했습니다.");
+      // 그 밖의 예외 처리
+      errorMessage = "인증에 실패했습니다.";
     }
+    
+    String htmlResponse = "<html>" +
+        "<head><meta charset='UTF-8'></head>" +
+        "<body>" +
+        "<script>" +
+        "alert('" + errorMessage + "');" +
+        "window.location.href = '" + redirectUrl + "';" +
+        "</script>" +
+        "</body>" +
+        "</html>";
+
+    // HTML 응답 작성
+    response.getWriter().write(htmlResponse);
   }
+
+
 }

--- a/src/main/java/com/beelinkers/englebee/auth/oauth2/exception/handler/CustomAuthenticationFailureHandler.java
+++ b/src/main/java/com/beelinkers/englebee/auth/oauth2/exception/handler/CustomAuthenticationFailureHandler.java
@@ -1,6 +1,7 @@
 package com.beelinkers.englebee.auth.oauth2.exception.handler;
 
 import com.beelinkers.englebee.auth.oauth2.exception.AlreadySignedUpEmailException;
+import com.beelinkers.englebee.auth.oauth2.exception.DeactivatedMemberException;
 import com.beelinkers.englebee.auth.oauth2.exception.SignupRequiredException;
 import com.beelinkers.englebee.auth.oauth2.exception.UnsupportedSocialLoginTypeException;
 import jakarta.servlet.ServletException;
@@ -28,6 +29,10 @@ public class CustomAuthenticationFailureHandler implements AuthenticationFailure
     } else if (exception instanceof AlreadySignedUpEmailException) {
       // 이미 다른 소셜 로그인 타입으로 회원가입 완료된 경우
       response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+      response.getWriter().write(exception.getMessage());
+    } else if (exception instanceof DeactivatedMemberException) {
+      // 회원탈퇴 처리된 계정인 경우
+      response.setStatus(HttpServletResponse.SC_FORBIDDEN);
       response.getWriter().write(exception.getMessage());
     } else {
       // 그 밖 예외 처리

--- a/src/main/java/com/beelinkers/englebee/auth/oauth2/session/SessionMember.java
+++ b/src/main/java/com/beelinkers/englebee/auth/oauth2/session/SessionMember.java
@@ -5,11 +5,13 @@ import com.beelinkers.englebee.auth.domain.entity.Role;
 import java.io.Serializable;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 @AllArgsConstructor
 public class SessionMember implements Serializable {
 
-  private final Long seq;
-  private final Role role;
+  private Long seq;
+  private Role role;
 }

--- a/src/main/java/com/beelinkers/englebee/auth/oauth2/session/SignupProgressSessionMember.java
+++ b/src/main/java/com/beelinkers/englebee/auth/oauth2/session/SignupProgressSessionMember.java
@@ -4,12 +4,14 @@ import com.beelinkers.englebee.auth.domain.entity.LoginType;
 import java.io.Serializable;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 @AllArgsConstructor
 public class SignupProgressSessionMember implements Serializable {
 
-  private final String email;
+  private String email;
 
-  private final LoginType loginType;
+  private LoginType loginType;
 }

--- a/src/main/java/com/beelinkers/englebee/auth/oauth2/userinfo/CustomOAuth2UserService.java
+++ b/src/main/java/com/beelinkers/englebee/auth/oauth2/userinfo/CustomOAuth2UserService.java
@@ -7,6 +7,7 @@ import com.beelinkers.englebee.auth.domain.entity.LoginType;
 import com.beelinkers.englebee.auth.domain.entity.Member;
 import com.beelinkers.englebee.auth.domain.repository.MemberRepository;
 import com.beelinkers.englebee.auth.oauth2.exception.AlreadySignedUpEmailException;
+import com.beelinkers.englebee.auth.oauth2.exception.DeactivatedMemberException;
 import com.beelinkers.englebee.auth.oauth2.exception.SignupRequiredException;
 import com.beelinkers.englebee.auth.oauth2.exception.UnsupportedSocialLoginTypeException;
 import com.beelinkers.englebee.auth.oauth2.session.SessionMember;
@@ -59,6 +60,10 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
       if (!member.getLoginType().equals(loginAttemptedType)) {
         throw new AlreadySignedUpEmailException(
             "이미 다른 소셜로그인 계정으로 가입된 이메일입니다. 해당 소셜 로그인 계정으로 로그인해주세요.");
+      }
+
+      if (member.isDeactivated()) {
+        throw new DeactivatedMemberException("회원 탈퇴 처리된 계정입니다.");
       }
 
       httpSession.invalidate();

--- a/src/main/java/com/beelinkers/englebee/auth/oauth2/userinfo/CustomOAuth2UserService.java
+++ b/src/main/java/com/beelinkers/englebee/auth/oauth2/userinfo/CustomOAuth2UserService.java
@@ -51,8 +51,10 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     Optional<Member> optionalMember = memberRepository.findByEmail(email);
 
     if (optionalMember.isEmpty()) {
-      httpSession.setAttribute(SIGNUP_PROGRESS_SESSION_MEMBER_KEY,
-          new SignupProgressSessionMember(email, loginAttemptedType));
+      if (httpSession.getAttribute(SIGNUP_PROGRESS_SESSION_MEMBER_KEY) == null) {
+        httpSession.setAttribute(SIGNUP_PROGRESS_SESSION_MEMBER_KEY,
+            new SignupProgressSessionMember(email, loginAttemptedType));
+      }
       throw new SignupRequiredException("회원가입 미완료 : 추가 회원가입 페이지로 이동");
     } else {
       Member member = optionalMember.get();

--- a/src/main/java/com/beelinkers/englebee/auth/oauth2/userinfo/GoogleResponse.java
+++ b/src/main/java/com/beelinkers/englebee/auth/oauth2/userinfo/GoogleResponse.java
@@ -23,6 +23,6 @@ public class GoogleResponse implements OAuth2Response, Serializable {
 
   @Override
   public String getName() {
-    return "google-" + attributes.get("email").toString();
+    return attributes.get("sub").toString();
   }
 }

--- a/src/main/java/com/beelinkers/englebee/auth/service/AuthService.java
+++ b/src/main/java/com/beelinkers/englebee/auth/service/AuthService.java
@@ -12,6 +12,5 @@ public interface AuthService {
 
   Member signupTeacher(SignupProgressSessionMember signupProgressSessionMember,
       TeacherSignupRequestDTO teacherSignupRequestDTO);
-
-  void deactivateAccount(Long memberSeq);
+  
 }

--- a/src/main/java/com/beelinkers/englebee/auth/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/beelinkers/englebee/auth/service/impl/AuthServiceImpl.java
@@ -9,7 +9,6 @@ import com.beelinkers.englebee.auth.dto.request.TeacherSignupRequestDTO;
 import com.beelinkers.englebee.auth.oauth2.session.SignupProgressSessionMember;
 import com.beelinkers.englebee.auth.service.AuthService;
 import com.beelinkers.englebee.general.exception.MemberNicknameDuplicatedException;
-import com.beelinkers.englebee.general.exception.MemberNotFoundException;
 import com.beelinkers.englebee.general.service.GeneralMemberService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -56,15 +55,6 @@ public class AuthServiceImpl implements AuthService {
         .build();
     log.info("선생님 회원 가입 완료 : {}", teacher.getNickname());
     return memberRepository.save(teacher);
-  }
-
-  @Override
-  public void deactivateAccount(Long memberSeq) {
-    Member member = memberRepository.findById(memberSeq)
-        .orElseThrow(() -> new MemberNotFoundException("해당 유저가 존재하지 않습니다."));
-    if (!member.isDeactivated()) {
-      member.deactivate();
-    }
   }
 
   private void checkNicknameDuplicated(String nickname) {

--- a/src/main/java/com/beelinkers/englebee/auth/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/beelinkers/englebee/auth/service/impl/AuthServiceImpl.java
@@ -8,7 +8,6 @@ import com.beelinkers.englebee.auth.dto.request.StudentSignupRequestDTO;
 import com.beelinkers.englebee.auth.dto.request.TeacherSignupRequestDTO;
 import com.beelinkers.englebee.auth.oauth2.session.SignupProgressSessionMember;
 import com.beelinkers.englebee.auth.service.AuthService;
-import com.beelinkers.englebee.general.exception.MemberNicknameDuplicatedException;
 import com.beelinkers.englebee.general.service.GeneralMemberService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -58,8 +57,6 @@ public class AuthServiceImpl implements AuthService {
   }
 
   private void checkNicknameDuplicated(String nickname) {
-    if (generalMemberService.checkNicknameDuplicated(nickname)) {
-      throw new MemberNicknameDuplicatedException("중복된 닉네임입니다.");
-    }
+    generalMemberService.checkNicknameDuplicated(nickname);
   }
 }

--- a/src/main/java/com/beelinkers/englebee/general/controller/api/MemberApiController.java
+++ b/src/main/java/com/beelinkers/englebee/general/controller/api/MemberApiController.java
@@ -26,9 +26,8 @@ public class MemberApiController {
     if (nickname.length() > 20 || nickname.isEmpty()) {
       throw new MemberNicknameLengthException("닉네임의 길이는 1글자 ~ 20글자 사이여야 합니다.");
     }
-
-    return ResponseEntity.ok()
-        .body(generalMemberService.checkNicknameDuplicated(nickname));
+    generalMemberService.checkNicknameDuplicated(nickname);
+    return ResponseEntity.ok().build();
   }
 
 

--- a/src/main/java/com/beelinkers/englebee/general/controller/page/MainPageController.java
+++ b/src/main/java/com/beelinkers/englebee/general/controller/page/MainPageController.java
@@ -19,10 +19,11 @@ public class MainPageController {
 
   @GetMapping("/main")
   public String getMainPage(@LoginMember SessionMember sessionMember, Model model) {
-
     if (sessionMember == null) {
       return "index";
     }
+
+    log.info("LoginMember = {}", sessionMember.getRole());
 
     Long memberSeq = sessionMember.getSeq();
     model.addAttribute("nickname", mainPageService.getNickname(memberSeq));

--- a/src/main/java/com/beelinkers/englebee/general/controller/page/MainPageController.java
+++ b/src/main/java/com/beelinkers/englebee/general/controller/page/MainPageController.java
@@ -23,8 +23,6 @@ public class MainPageController {
       return "index";
     }
 
-    log.info("LoginMember = {}", sessionMember.getRole());
-
     Long memberSeq = sessionMember.getSeq();
     model.addAttribute("nickname", mainPageService.getNickname(memberSeq));
     model.addAttribute("memberSeq", memberSeq);

--- a/src/main/java/com/beelinkers/englebee/general/domain/entity/LevelCode.java
+++ b/src/main/java/com/beelinkers/englebee/general/domain/entity/LevelCode.java
@@ -1,8 +1,6 @@
 package com.beelinkers.englebee.general.domain.entity;
 
 import com.beelinkers.englebee.general.exception.InvalidLevelCodeException;
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonValue;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -18,7 +16,6 @@ public enum LevelCode {
 
   private final String koreanCode;
 
-  @JsonCreator
   public static LevelCode fromKoreanCode(String koreanCode) {
     for (LevelCode level : values()) {
       if (level.getKoreanCode().equals(koreanCode)) {
@@ -28,9 +25,8 @@ public enum LevelCode {
     throw new InvalidLevelCodeException("유효하지 않은 레벨 입력입니다: " + koreanCode);
   }
 
-  @JsonValue
   public String getKoreanCode() {
     return koreanCode;
   }
-
+  
 }

--- a/src/main/java/com/beelinkers/englebee/general/domain/entity/LevelCode.java
+++ b/src/main/java/com/beelinkers/englebee/general/domain/entity/LevelCode.java
@@ -24,9 +24,5 @@ public enum LevelCode {
     }
     throw new InvalidLevelCodeException("유효하지 않은 레벨 입력입니다: " + koreanCode);
   }
-
-  public String getKoreanCode() {
-    return koreanCode;
-  }
   
 }

--- a/src/main/java/com/beelinkers/englebee/general/service/GeneralMemberService.java
+++ b/src/main/java/com/beelinkers/englebee/general/service/GeneralMemberService.java
@@ -2,6 +2,6 @@ package com.beelinkers.englebee.general.service;
 
 public interface GeneralMemberService {
 
-  Boolean checkNicknameDuplicated(String nickname);
+  void checkNicknameDuplicated(String nickname);
 
 }

--- a/src/main/java/com/beelinkers/englebee/general/service/impl/GeneralMemberServiceImpl.java
+++ b/src/main/java/com/beelinkers/englebee/general/service/impl/GeneralMemberServiceImpl.java
@@ -19,6 +19,7 @@ public class GeneralMemberServiceImpl implements GeneralMemberService {
   @Override
   @Transactional(readOnly = true)
   public void checkNicknameDuplicated(String nickname) {
+    log.info("given nickname = {}", nickname);
     boolean present = memberRepository.findByNickname(nickname).isPresent();
     if (present) {
       throw new MemberNicknameDuplicatedException("중복된 닉네임입니다.");

--- a/src/main/java/com/beelinkers/englebee/general/service/impl/GeneralMemberServiceImpl.java
+++ b/src/main/java/com/beelinkers/englebee/general/service/impl/GeneralMemberServiceImpl.java
@@ -19,7 +19,6 @@ public class GeneralMemberServiceImpl implements GeneralMemberService {
   @Override
   @Transactional(readOnly = true)
   public void checkNicknameDuplicated(String nickname) {
-    log.info("given nickname = {}", nickname);
     boolean present = memberRepository.findByNickname(nickname).isPresent();
     if (present) {
       throw new MemberNicknameDuplicatedException("중복된 닉네임입니다.");

--- a/src/main/java/com/beelinkers/englebee/general/service/impl/GeneralMemberServiceImpl.java
+++ b/src/main/java/com/beelinkers/englebee/general/service/impl/GeneralMemberServiceImpl.java
@@ -1,6 +1,7 @@
 package com.beelinkers.englebee.general.service.impl;
 
 import com.beelinkers.englebee.auth.domain.repository.MemberRepository;
+import com.beelinkers.englebee.general.exception.MemberNicknameDuplicatedException;
 import com.beelinkers.englebee.general.service.GeneralMemberService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,7 +18,10 @@ public class GeneralMemberServiceImpl implements GeneralMemberService {
 
   @Override
   @Transactional(readOnly = true)
-  public Boolean checkNicknameDuplicated(String nickname) {
-    return memberRepository.findByNickname(nickname).isPresent();
+  public void checkNicknameDuplicated(String nickname) {
+    boolean present = memberRepository.findByNickname(nickname).isPresent();
+    if (present) {
+      throw new MemberNicknameDuplicatedException("중복된 닉네임입니다.");
+    }
   }
 }

--- a/src/main/java/com/beelinkers/englebee/global/GlobalExceptionHandler.java
+++ b/src/main/java/com/beelinkers/englebee/global/GlobalExceptionHandler.java
@@ -1,0 +1,19 @@
+package com.beelinkers.englebee.global;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  public ResponseEntity<String> handleMethodArgumentNotValidException(
+      MethodArgumentNotValidException ex) {
+    String errorMessage = ex.getBindingResult().getAllErrors().get(0).getDefaultMessage();
+    return new ResponseEntity<>(errorMessage, HttpStatus.BAD_REQUEST);
+  }
+
+}

--- a/src/main/java/com/beelinkers/englebee/global/GlobalTempConstant.java
+++ b/src/main/java/com/beelinkers/englebee/global/GlobalTempConstant.java
@@ -1,7 +1,0 @@
-package com.beelinkers.englebee.global;
-
-public class GlobalTempConstant {
-
-  public static final int MY_PAGE_QNA_QUESTION_SIZE = 5;
-  // etc...
-}

--- a/src/main/java/com/beelinkers/englebee/student/controller/api/StudentAccountApiController.java
+++ b/src/main/java/com/beelinkers/englebee/student/controller/api/StudentAccountApiController.java
@@ -37,8 +37,8 @@ public class StudentAccountApiController {
   // nickname 중복 검사(general)
   @PostMapping("/check-nickname")
   public ResponseEntity<Boolean> checkNicknameDuplicated(@RequestParam String nickname) {
-    boolean isDuplicated = studentAccountService.checkNicknameDuplicated(nickname);
-    return ResponseEntity.ok(isDuplicated);
+    studentAccountService.checkNicknameDuplicated(nickname);
+    return ResponseEntity.ok().build();
   }
 
   // 학생 계정 정보 수정

--- a/src/main/java/com/beelinkers/englebee/student/service/StudentAccountService.java
+++ b/src/main/java/com/beelinkers/englebee/student/service/StudentAccountService.java
@@ -10,7 +10,7 @@ public interface StudentAccountService {
 
   void deleteStudentAccountInfo(Long memberSeq);
 
-  boolean checkNicknameDuplicated(String nickname);
+  void checkNicknameDuplicated(String nickname);
 
   Member getMemberInfo(Long memberSeq);
 }

--- a/src/main/java/com/beelinkers/englebee/student/service/impl/StudentAccountServiceImpl.java
+++ b/src/main/java/com/beelinkers/englebee/student/service/impl/StudentAccountServiceImpl.java
@@ -32,8 +32,8 @@ public class StudentAccountServiceImpl implements StudentAccountService {
   // 닉네임 중복 검사
   @Override
   @Transactional
-  public boolean checkNicknameDuplicated(String nickname) {
-    return generalMemberService.checkNicknameDuplicated(nickname);
+  public void checkNicknameDuplicated(String nickname) {
+    generalMemberService.checkNicknameDuplicated(nickname);
   }
 
   // 회원 정보 수정

--- a/src/main/java/com/beelinkers/englebee/teacher/controller/api/TeacherAccountApiController.java
+++ b/src/main/java/com/beelinkers/englebee/teacher/controller/api/TeacherAccountApiController.java
@@ -39,8 +39,8 @@ public class TeacherAccountApiController {
   // nickname 중복 검사
   @PostMapping("/check-nickname")
   public ResponseEntity<Boolean> checkNicknameDuplicated(@RequestParam String nickname) {
-    boolean isDuplicated = teacherAccountService.checkNicknameDuplicate(nickname);
-    return ResponseEntity.ok(isDuplicated);
+    teacherAccountService.checkNicknameDuplicate(nickname);
+    return ResponseEntity.ok().build();
   }
 
   // 선생님 계정 정보 수정

--- a/src/main/java/com/beelinkers/englebee/teacher/service/TeacherAccountService.java
+++ b/src/main/java/com/beelinkers/englebee/teacher/service/TeacherAccountService.java
@@ -11,7 +11,7 @@ public interface TeacherAccountService {
   TeacherAccountUpdateDTO updateTeacherInfo(Long memberSeq,
       TeacherAccountPageRequestDTO teacherAccountRequestDTO);
 
-  boolean checkNicknameDuplicate(String nickname);
+  void checkNicknameDuplicate(String nickname);
 
   void deleteTeacherAccountInfo(Long memberSeq);
 

--- a/src/main/java/com/beelinkers/englebee/teacher/service/impl/TeacherAccountServiceImpl.java
+++ b/src/main/java/com/beelinkers/englebee/teacher/service/impl/TeacherAccountServiceImpl.java
@@ -34,8 +34,8 @@ public class TeacherAccountServiceImpl implements TeacherAccountService {
 
   @Override
   @Transactional(readOnly = true)
-  public boolean checkNicknameDuplicate(String nickname) {
-    return generalMemberService.checkNicknameDuplicated(nickname);
+  public void checkNicknameDuplicate(String nickname) {
+    generalMemberService.checkNicknameDuplicated(nickname);
   }
 
   @Override

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -27,6 +27,3 @@ spring.security.oauth2.client.provider.naver.user-info-uri=https://openapi.naver
 spring.security.oauth2.client.provider.naver.user-name-attribute=response
 # ?? ???? ?? ?? INFO (?? ??? ??? ? WARN)
 logging.level.root=INFO
-# ThymeLeaf ? ???? ?? ??
-spring.thymeleaf.prefix=classpath:/templates/
-spring.thymeleaf.suffix=.html

--- a/src/main/resources/templates/auth/signup-progress.html
+++ b/src/main/resources/templates/auth/signup-progress.html
@@ -61,7 +61,7 @@
                                                             <label class="middle mb-1"><b>닉네임을 입력하세요 (최대 20자)</b></label>
                                                             <div class="mb-3 d-flex align-items-center">
                                                                 <input class="form-control me-2" style="width: 300px;" id="student-nickname" type="text" placeholder="닉네임">
-                                                                <button class="btn btn-primary" style="width: auto;" id="nickname-duplicated-check-btn">중복확인</button>
+                                                                <button class="btn btn-primary" style="width: auto;" id="student-nickname-duplicated-check-btn">중복확인</button>
                                                             </div>
                                                         </div>
 
@@ -69,13 +69,13 @@
                                                         <div class="mb-3 col-md-6">
                                                             <label class="middle mb-1"><b>학년을 입력하세요.</b></label>
                                                             <div class="mb-3 col-md-12">
-                                                                <select name="mh" class="form-control">
-                                                                    <option value="m1" selected="">중1</option>
-                                                                    <option value="m2">중2</option>
-                                                                    <option value="m3">중3</option>
-                                                                    <option value="h1">고1</option>
-                                                                    <option value="h2">고2</option>
-                                                                    <option value="h3">고3</option>
+                                                                <select id="student-grade-select" class="form-control">
+                                                                    <option value="중1" selected>중1</option>
+                                                                    <option value="중2">중2</option>
+                                                                    <option value="중3">중3</option>
+                                                                    <option value="고1">고1</option>
+                                                                    <option value="고2">고2</option>
+                                                                    <option value="고3">고3</option>
                                                                 </select>
                                                             </div>
                                                         </div>
@@ -84,21 +84,69 @@
                                                     <div class="mb-3 col-md-12">
                                                         <label class="middle mb-1"><b>개인정보 수집동의 약관</b></label>
                                                            <div class="mb-3 col-md-12">
-<textarea class="form-control" rows="20">개인정보 수집동의
+<textarea class="form-control" rows="20">
+  [ 개인정보 수집동의 ]
 
-개인정보는 ㅇㅇㅇㅇㅇㅇ 합니다.
-개인정보는 ㅇㅇㅇㅇㅇㅇ 합니다.
-개인정보는 ㅇㅇㅇㅇㅇㅇ 합니다.
-</textarea>
-                                                            </div>
+  EngleBee는 학생의 학습 경험을 향상시키기 위해 아래와 같은 개인정보를 수집하고 이용합니다.
+  학생 계정으로 가입하시면 다음과 같은 내용에 동의하게 됩니다.
+
+  [ 수집하는 개인정보 항목 ]
+
+  필수 정보: 학년 정보, 과목별 성취도
+  선택 정보: 학습 목표, 선호 학습 스타일, 관심 분야
+
+  [ 개인정보의 수집 및 이용 목적 ]
+
+  - 학습 성과 분석 및 맞춤형 학습 컨텐츠 제공
+
+  - 서비스 개선을 위한 데이터 분석 및 통계 작성
+
+  - 신규 서비스 개발 및 개인 맞춤형 서비스 제공
+
+  [ 개인정보의 보유 및 이용 기간 ]
+
+  - 필수 정보 : 학년 정보, 과목별 성취도
+  해당 정보는 회원 탈퇴 시에도 유지됩니다.
+
+  - 선택 정보 :학습 목표, 선호 학습 스타일, 관심 분야
+  해당 정보는 회원 탈퇴 시 폐기됩니다.
+
+  [ 개인정보 제공 및 공유 ]
+
+  EngleBee는 원칙적으로 수집된 개인정보를 외부에 제공하지 않습니다.
+  다만, 법령의 규정에 의거하거나 수사 목적으로 법령에 정해진 절차와 방법에 따라
+  수사기관의 요구가 있는 경우에는 예외로 합니다.
+
+  [ 개인정보 처리의 위탁 ]
+
+  EngleBee는 서비스 운영에 필요한 경우 개인정보 처리 업무를 외부 전문 업체에 위탁할 수 있으며,
+  이 경우 철저한 관리·감독을 통해 개인정보 보호를 위해 노력합니다.
+
+  [ 이용자의 권리와 그 행사 방법 ]
+
+  이용자는 언제든지 자신의 개인정보를 조회하거나 수정할 수 있으며,
+  개인정보의 수집 및 이용에 대한 동의를 철회할 수 있습니다.
+  관련 문의는 고객센터를 통해 가능합니다.
+
+  [ 개인정보 보호를 위한 조치 ]
+
+  EngleBee는 개인정보 보호를 위해 기술적, 관리적 보호 조치를 시행하고 있으며,
+  개인정보 유출 방지를 위해 최선을 다하고 있습니다.
+
+  [ 동의 거부 권리 및 동의 거부 시 불이익 안내 ]
+
+  이용자는 개인정보 수집 및 이용에 대한 동의를 거부할 권리가 있습니다.
+  다만, 동의를 거부할 경우 EngleBee 맞춤형 학습 서비스 이용에 제한이 있을 수 있습니다.
+
+</textarea></div>
                                                     </div>
                                                     <div class="form-check">
-                                                        <input class="form-check-input"  type="checkbox" value="" checked>
+                                                        <input class="form-check-input"  id="student-term-agree-check" type="checkbox" value="" checked>
                                                         <label class="form-check-label" ><b>동의합니다.</b></label>
                                                     </div>
                                                     <hr class="my-4">
                                                     <div class="d-flex justify-content-center">
-                                                        <button class="btn btn-primary" type="button">회원가입</button>
+                                                        <button class="btn btn-primary" type="button" id="student-signup-btn">회원가입</button>
                                                     </div>
                                                     
                                                 </form>
@@ -176,13 +224,16 @@
       <div th:replace="~{fragments/scripts :: scripts}" ></div>
       <script>
         $(document).ready(function () {
-          const $nicknameInput = $('#student-nickname');
-          const $checkButton = $('#nickname-duplicated-check-btn');
+          const $studentNicknameInput = $('#student-nickname');
+          const $studentNicknameCheckButton = $('#student-nickname-duplicated-check-btn');
+          const $studentAgreeCheckbox = $('#student-term-agree-check');
+          const $studentSignupButton = $('#student-signup-btn');
 
-          $checkButton.on('click', function (event) {
+          $studentSignupButton.prop('disabled', true);
+
+          $studentNicknameCheckButton.on('click', function (event) {
             event.preventDefault();
-
-            const nickname = $nicknameInput.val().trim();
+            const nickname = $studentNicknameInput.val().trim();
 
             if (nickname === '') {
               alert('닉네임을 입력하세요.');
@@ -196,10 +247,11 @@
               data: JSON.stringify({ 'nickname': nickname }),
               success: function (response) {
                 alert('사용 가능한 닉네임 입니다.');
-                $checkButton.removeClass('btn-primary')
+                $studentNicknameCheckButton.removeClass('btn-primary')
                 .addClass('btn-success')
                 .text('사용가능')
                 .prop('disabled', true); // 버튼 비활성화
+                checkFormValidity(); // 폼 유효성 체크
               },
               error: function (xhr) {
                 if (xhr.status >= 400 && xhr.status < 500) {
@@ -212,15 +264,63 @@
             });
           });
 
-          // 닉네임 입력값이 변경될 때 버튼을 활성화하고 텍스트를 "중복확인"으로 변경
-          $nicknameInput.on('input', function () {
-            $checkButton.removeClass('btn-success')
+          $studentNicknameInput.on('input', function () {
+            $studentNicknameCheckButton.removeClass('btn-success')
             .addClass('btn-primary')
             .text('중복확인')
-            .prop('disabled', false); // 버튼 활성화
+            .prop('disabled', false);
+            checkFormValidity();
+          });
+
+          // 개인정보 수집 동의 체크박스 변경 시 폼 유효성 체크
+          $studentAgreeCheckbox.on('change', function () {
+            checkFormValidity();
+          });
+
+          function checkFormValidity() {
+            const isNicknameChecked = $studentNicknameCheckButton.hasClass('btn-success');
+            const isAgreeChecked = $studentAgreeCheckbox.is(':checked');
+
+            if (isNicknameChecked && isAgreeChecked) {
+              $studentSignupButton.prop('disabled', false);
+            } else {
+              $studentSignupButton.prop('disabled', true);
+            }
+          }
+
+          // 회원가입 버튼 클릭 시 이벤트
+          $studentSignupButton.on('click', function (event) {
+            event.preventDefault();
+            const nickname = $studentNicknameInput.val().trim();
+            const grade = $('#student-grade-select').val();
+            const personalInfoCollectionAgreed = $studentAgreeCheckbox.is(':checked');
+
+            const data = {
+              'nickname': nickname,
+              'grade': grade,
+              'personalInfoCollectionAgreed': personalInfoCollectionAgreed
+            };
+
+            $.ajax({
+              url: '/api/auth/signup/student',
+              type: 'POST',
+              contentType: 'application/json',
+              data: JSON.stringify(data),
+              success: function (response) {
+                alert('회원가입이 성공적으로 완료되었습니다!');
+                window.location.href = '/main';
+              },
+              error: function (xhr) {
+                if (xhr.status >= 400 && xhr.status < 500) {
+                  const errorMessage = xhr.responseText || '클라이언트 오류가 발생했습니다.';
+                  alert(errorMessage);
+                } else {
+                  alert('서버 오류가 발생했습니다.');
+                }
+              }
+            });
           });
         });
-
       </script>
 
 

--- a/src/main/resources/templates/auth/signup-progress.html
+++ b/src/main/resources/templates/auth/signup-progress.html
@@ -6,7 +6,7 @@
 <body  class="bg-white">
     
     	<!-- --------------------------- [FRAGMENT : 상단 네이게이션바]  ------------------------------------->
-        <div th:replace="~{fragments/top-nav :: top-nav}"></div>
+        <div th:replace="~{fragments/top-nav-without-menu:: top-nav-without-menu}"></div>
 
         <div id="layoutSidenav">
             <div id="layoutSidenav_nav">
@@ -307,7 +307,7 @@
               contentType: 'application/json',
               data: JSON.stringify(data),
               success: function (response) {
-                alert('회원가입이 성공적으로 완료되었습니다!');
+                alert('회원가입이 성공적으로 완료되었습니다. 다시 로그인 해주세요!');
                 window.location.href = '/main';
               },
               error: function (xhr) {

--- a/src/main/resources/templates/auth/signup-progress.html
+++ b/src/main/resources/templates/auth/signup-progress.html
@@ -3,325 +3,499 @@
 
 <head th:replace="~{fragments/header :: head}"></head>
 
-<body  class="bg-white">
-    
-    	<!-- --------------------------- [FRAGMENT : 상단 네이게이션바]  ------------------------------------->
-        <div th:replace="~{fragments/top-nav-without-menu:: top-nav-without-menu}"></div>
+<body class="bg-white">
 
-        <div id="layoutSidenav">
-            <div id="layoutSidenav_nav">
+<!-- --------------------------- [FRAGMENT : 상단 네이게이션바]  ------------------------------------->
+<div th:replace="~{fragments/top-nav-without-menu:: top-nav-without-menu}"></div>
+
+<div id="layoutSidenav">
+  <div id="layoutSidenav_nav">
+  </div>
+  <div id="layoutSidenav_content">
+    <main>
+      <!-- --------------------------- [FRAGMENT : 배너]  ------------------------------------->
+      <div th:replace="~{fragments/top-banner :: top-banner}"></div>
+
+      <!-- --------------------------- [중앙 : 컨텐츠 START]  ------------------------------------->
+      <div class="container-xl px-4 mt-n10">
+
+        <div class="card">
+          <div class="card-header border-bottom">
+            <!-- Wizard navigation-->
+            <div class="nav nav-pills nav-justified flex-column flex-xl-row nav-wizard" id="cardTab"
+                 role="tablist">
+
+              <!-- 학생 회원가입 타이틀 -->
+              <a class="nav-item nav-link active" id="wizard1-tab" href="#wizard1"
+                 data-bs-toggle="tab" role="tab" aria-controls="wizard1" aria-selected="true">
+                <div class="wizard-step-icon">1</div>
+                <div class="wizard-step-text">
+                  <div class="wizard-step-text-name">학생 회원가입</div>
+                  <div class="wizard-step-text-details">학생 계정으로 회원가입 합니다.</div>
+                </div>
+              </a>
+              <!-- 선생님 회원가입 타이틀 -->
+              <a class="nav-item nav-link" id="wizard2-tab" href="#wizard2" data-bs-toggle="tab"
+                 role="tab" aria-controls="wizard2" aria-selected="false" tabindex="-1">
+                <div class="wizard-step-icon">2</div>
+                <div class="wizard-step-text">
+                  <div class="wizard-step-text-name">선생님 회원가입</div>
+                  <div class="wizard-step-text-details">선생님 계정으로 회원가입 합니다.</div>
+                </div>
+              </a>
+
             </div>
-            <div id="layoutSidenav_content">
-                <main>
-                	<!-- --------------------------- [FRAGMENT : 배너]  ------------------------------------->
-                    <div th:replace="~{fragments/top-banner :: top-banner}"></div>
+          </div>
+          <div class="card-body">
+            <div class="tab-content" id="cardTabContent">
+              <!-- 학생 회원가입 폼 -->
+              <div class="tab-pane py-2 py-xl-3 fade show active" id="wizard1" role="tabpanel"
+                   aria-labelledby="wizard1-tab">
+                <div class="row justify-content-center">
+                  <div class="col-10">
 
+                    <form>
+                      <div class="row gx-3">
 
-                    <!-- --------------------------- [중앙 : 컨텐츠 START]  ------------------------------------->
-                    <div class="container-xl px-4 mt-n10">
-                        
-                        
-                        <div class="card">
-                            <div class="card-header border-bottom">
-                                <!-- Wizard navigation-->
-
-                                <div class="nav nav-pills nav-justified flex-column flex-xl-row nav-wizard" id="cardTab" role="tablist">
-                                    
-                                    <!-- 학생 회원가입  타이틀 -->
-                                    <a class="nav-item nav-link active" id="wizard1-tab" href="#wizard1" data-bs-toggle="tab" role="tab" aria-controls="wizard1" aria-selected="true">
-                                        <div class="wizard-step-icon">1</div>
-                                        <div class="wizard-step-text">
-                                            <div class="wizard-step-text-name">학생 회원가입</div>
-                                            <div class="wizard-step-text-details">학생 계정으로 회원가입 합니다.</div>
-                                        </div>
-                                    </a>
-                                    <!-- 선생님 회원가입 타이틀 -->
-                                    <a class="nav-item nav-link" id="wizard2-tab" href="#wizard2" data-bs-toggle="tab" role="tab" aria-controls="wizard2" aria-selected="false" tabindex="-1">
-                                        <div class="wizard-step-icon">2</div>
-                                        <div class="wizard-step-text">
-                                            <div class="wizard-step-text-name">선생님 회원가입</div>
-                                            <div class="wizard-step-text-details">선생님 계정으로 회원가입 합니다.</div>
-                                        </div>
-                                    </a>
-
-                                   
-                                </div>
-                            </div>
-                            <div class="card-body">
-                                <div class="tab-content" id="cardTabContent">
-                                    <!-- 학생 회원가입 폼 -->
-                                    <div class="tab-pane py-2 py-xl-3 fade show active" id="wizard1" role="tabpanel" aria-labelledby="wizard1-tab">
-                                        <div class="row justify-content-center">
-                                            <div class="col-10"> 
-
-                                                <form>
-                                                    <div class="row gx-3">
-
-                                                        <div class="mb-3 col-md-6">
-                                                            <label class="middle mb-1"><b>닉네임을 입력하세요 (최대 20자)</b></label>
-                                                            <div class="mb-3 d-flex align-items-center">
-                                                                <input class="form-control me-2" style="width: 300px;" id="student-nickname" type="text" placeholder="닉네임">
-                                                                <button class="btn btn-primary" style="width: auto;" id="student-nickname-duplicated-check-btn">중복확인</button>
-                                                            </div>
-                                                        </div>
-
-
-                                                        <div class="mb-3 col-md-6">
-                                                            <label class="middle mb-1"><b>학년을 입력하세요.</b></label>
-                                                            <div class="mb-3 col-md-12">
-                                                                <select id="student-grade-select" class="form-control">
-                                                                    <option value="중1" selected>중1</option>
-                                                                    <option value="중2">중2</option>
-                                                                    <option value="중3">중3</option>
-                                                                    <option value="고1">고1</option>
-                                                                    <option value="고2">고2</option>
-                                                                    <option value="고3">고3</option>
-                                                                </select>
-                                                            </div>
-                                                        </div>
-                                                    </div>
-
-                                                    <div class="mb-3 col-md-12">
-                                                        <label class="middle mb-1"><b>개인정보 수집동의 약관</b></label>
-                                                           <div class="mb-3 col-md-12">
-<textarea class="form-control" rows="20">
-  [ 개인정보 수집동의 ]
-
-  EngleBee는 학생의 학습 경험을 향상시키기 위해 아래와 같은 개인정보를 수집하고 이용합니다.
-  학생 계정으로 가입하시면 다음과 같은 내용에 동의하게 됩니다.
-
-  [ 수집하는 개인정보 항목 ]
-
-  필수 정보: 학년 정보, 과목별 성취도
-  선택 정보: 학습 목표, 선호 학습 스타일, 관심 분야
-
-  [ 개인정보의 수집 및 이용 목적 ]
-
-  - 학습 성과 분석 및 맞춤형 학습 컨텐츠 제공
-
-  - 서비스 개선을 위한 데이터 분석 및 통계 작성
-
-  - 신규 서비스 개발 및 개인 맞춤형 서비스 제공
-
-  [ 개인정보의 보유 및 이용 기간 ]
-
-  - 필수 정보 : 학년 정보, 과목별 성취도
-  해당 정보는 회원 탈퇴 시에도 유지됩니다.
-
-  - 선택 정보 :학습 목표, 선호 학습 스타일, 관심 분야
-  해당 정보는 회원 탈퇴 시 폐기됩니다.
-
-  [ 개인정보 제공 및 공유 ]
-
-  EngleBee는 원칙적으로 수집된 개인정보를 외부에 제공하지 않습니다.
-  다만, 법령의 규정에 의거하거나 수사 목적으로 법령에 정해진 절차와 방법에 따라
-  수사기관의 요구가 있는 경우에는 예외로 합니다.
-
-  [ 개인정보 처리의 위탁 ]
-
-  EngleBee는 서비스 운영에 필요한 경우 개인정보 처리 업무를 외부 전문 업체에 위탁할 수 있으며,
-  이 경우 철저한 관리·감독을 통해 개인정보 보호를 위해 노력합니다.
-
-  [ 이용자의 권리와 그 행사 방법 ]
-
-  이용자는 언제든지 자신의 개인정보를 조회하거나 수정할 수 있으며,
-  개인정보의 수집 및 이용에 대한 동의를 철회할 수 있습니다.
-  관련 문의는 고객센터를 통해 가능합니다.
-
-  [ 개인정보 보호를 위한 조치 ]
-
-  EngleBee는 개인정보 보호를 위해 기술적, 관리적 보호 조치를 시행하고 있으며,
-  개인정보 유출 방지를 위해 최선을 다하고 있습니다.
-
-  [ 동의 거부 권리 및 동의 거부 시 불이익 안내 ]
-
-  이용자는 개인정보 수집 및 이용에 대한 동의를 거부할 권리가 있습니다.
-  다만, 동의를 거부할 경우 EngleBee 맞춤형 학습 서비스 이용에 제한이 있을 수 있습니다.
-
-</textarea></div>
-                                                    </div>
-                                                    <div class="form-check">
-                                                        <input class="form-check-input"  id="student-term-agree-check" type="checkbox" value="" checked>
-                                                        <label class="form-check-label" ><b>동의합니다.</b></label>
-                                                    </div>
-                                                    <hr class="my-4">
-                                                    <div class="d-flex justify-content-center">
-                                                        <button class="btn btn-primary" type="button" id="student-signup-btn">회원가입</button>
-                                                    </div>
-                                                    
-                                                </form>
-                                            </div>
-                                        </div>
-                                    </div>
-                                    <!-- 선생님 회원가입 폼 -->
-                                    <div class="tab-pane py-2 py-xl-3 fade" id="wizard2" role="tabpanel" aria-labelledby="wizard2-tab">
-
-                                        <div class="row justify-content-center">
-                                            <div class="col-10">
-                                                <form>
-                                                    <div class="row gx-3">
-
-                                                        <div class="mb-3 col-md-6">
-                                                            <label class="middle mb-1"><b>닉네임을 입력하세요 (최대 20자)</b></label>
-                                                            <div class="mb-3 d-flex align-items-center">
-                                                                <input class="form-control me-2" style="width: 300px;" id="teacher-nickname" type="text" placeholder="닉네임">
-                                                                <button class="btn btn-primary" style="width: auto;">중복확인</button>
-                                                            </div>
-                                                        </div>
-
-
-                                                    <div class="mb-3 col-md-12">
-                                                        <label class="middle mb-1"><b>개인정보 수집동의 약관</b></label>
-                                                        <div class="mb-3 col-md-12">
-<textarea class="form-control" rows="20">개인정보 수집동의
-
-개인정보는 ㅇㅇㅇㅇㅇㅇ 합니다.
-개인정보는 ㅇㅇㅇㅇㅇㅇ 합니다.
-개인정보는 ㅇㅇㅇㅇㅇㅇ 합니다.
-</textarea>
-                                                        </div>
-                                                    </div>
-                                                    <div class="form-check">
-                                                        <input class="form-check-input"  type="checkbox" value="" checked>
-                                                        <label class="form-check-label" ><b>동의합니다.</b></label>
-                                                    </div>
-                                                    <hr class="my-4">
-                                                    <div class="d-flex justify-content-center">
-                                                        <button class="btn btn-primary" type="button">회원가입</button>
-                                                    </div>
-
-                                                </form>
-                                            </div>
-                                        </div>
-
-
-                                    </div>
-
-
-                                </div>
-                            </div>
+                        <div class="mb-3 col-md-6">
+                          <label class="middle mb-1"><b>닉네임을 입력하세요 (최대 20자)</b></label>
+                          <div class="mb-3 d-flex align-items-center">
+                            <input class="form-control me-2" style="width: 300px;"
+                                   id="student-nickname" type="text" placeholder="닉네임">
+                            <button class="btn btn-primary" style="width: auto;"
+                                    id="student-nickname-duplicated-check-btn">중복확인
+                            </button>
+                          </div>
                         </div>
-                        
-                        
-                    </div>
-                    <!-- --------------------------- [중앙 : 컨텐츠 END]  ------------------------------------->
-                    
-                    
-                </main>
 
+                        <div class="mb-3 col-md-6">
+                          <label class="middle mb-1"><b>학년을 입력하세요.</b></label>
+                          <div class="mb-3 col-md-12">
+                            <select id="student-grade-select" class="form-control">
+                              <option value="중1" selected>중1</option>
+                              <option value="중2">중2</option>
+                              <option value="중3">중3</option>
+                              <option value="고1">고1</option>
+                              <option value="고2">고2</option>
+                              <option value="고3">고3</option>
+                            </select>
+                          </div>
+                        </div>
+                      </div>
 
+                      <div class="mb-3 col-md-12">
+                        <label class="middle mb-1"><b>개인정보 수집동의 약관</b></label>
+                        <div class="mb-3 col-md-12">
+                                                        <textarea class="form-control" rows="20">
+[ 개인정보 수집동의 ]
 
-                <!-- --------------------------- [FRAGMENT : 하단] ------------------------------------->
-                <footer th:replace="~{fragments/footer :: footer}"></footer>
+EngleBee는 학생의 학습 경험을 향상시키기 위해 아래와 같은 개인정보를 수집하고 이용합니다.
+학생 계정으로 가입하시면 다음과 같은 내용에 동의하게 됩니다.
+
+[ 수집하는 개인정보 항목 ]
+
+필수 정보: 학년 정보, 과목별 성취도
+선택 정보: 학습 목표, 선호 학습 스타일, 관심 분야
+
+[ 개인정보의 수집 및 이용 목적 ]
+
+- 학습 성과 분석 및 맞춤형 학습 컨텐츠 제공
+
+- 서비스 개선을 위한 데이터 분석 및 통계 작성
+
+- 신규 서비스 개발 및 개인 맞춤형 서비스 제공
+
+[ 개인정보의 보유 및 이용 기간 ]
+
+- 필수 정보 : 학년 정보, 과목별 성취도
+해당 정보는 회원 탈퇴 시에도 유지됩니다.
+
+- 선택 정보 :학습 목표, 선호 학습 스타일, 관심 분야
+해당 정보는 회원 탈퇴 시 폐기됩니다.
+
+[ 개인정보 제공 및 공유 ]
+
+EngleBee는 원칙적으로 수집된 개인정보를 외부에 제공하지 않습니다.
+다만, 법령의 규정에 의거하거나 수사 목적으로 법령에 정해진 절차와 방법에 따라
+수사기관의 요구가 있는 경우에는 예외로 합니다.
+
+[ 개인정보 처리의 위탁 ]
+
+EngleBee는 서비스 운영에 필요한 경우 개인정보 처리 업무를 외부 전문 업체에 위탁할 수 있으며,
+이 경우 철저한 관리·감독을 통해 개인정보 보호를 위해 노력합니다.
+
+[ 이용자의 권리와 그 행사 방법 ]
+
+이용자는 언제든지 자신의 개인정보를 조회하거나 수정할 수 있으며,
+개인정보의 수집 및 이용에 대한 동의를 철회할 수 있습니다.
+관련 문의는 고객센터를 통해 가능합니다.
+
+[ 개인정보 보호를 위한 조치 ]
+
+EngleBee는 개인정보 보호를 위해 기술적, 관리적 보호 조치를 시행하고 있으며,
+개인정보 유출 방지를 위해 최선을 다하고 있습니다.
+
+[ 동의 거부 권리 및 동의 거부 시 불이익 안내 ]
+
+이용자는 개인정보 수집 및 이용에 대한 동의를 거부할 권리가 있습니다.
+다만, 동의를 거부할 경우 EngleBee 맞춤형 학습 서비스 이용에 제한이 있을 수 있습니다.
+
+                                                        </textarea>
+                        </div>
+                      </div>
+                      <div class="form-check">
+                        <input class="form-check-input" id="student-term-agree-check"
+                               type="checkbox" value="" checked>
+                        <label class="form-check-label"><b>동의합니다.</b></label>
+                      </div>
+                      <hr class="my-4">
+                      <div class="d-flex justify-content-center">
+                        <button class="btn btn-primary" type="button" id="student-signup-btn">회원가입
+                        </button>
+                      </div>
+
+                    </form>
+                  </div>
+                </div>
+              </div>
+
+              <!-- 선생님 회원가입 폼 -->
+              <div class="tab-pane py-2 py-xl-3 fade" id="wizard2" role="tabpanel"
+                   aria-labelledby="wizard2-tab">
+                <div class="row justify-content-center">
+                  <div class="col-10">
+                    <form>
+                      <div class="row gx-3">
+
+                        <div class="mb-3 col-md-6">
+                          <label class="middle mb-1"><b>닉네임을 입력하세요 (최대 20자)</b></label>
+                          <div class="mb-3 d-flex align-items-center">
+                            <input class="form-control me-2" style="width: 300px;"
+                                   id="teacher-nickname" type="text" placeholder="닉네임">
+                            <button class="btn btn-primary" style="width: auto;"
+                                    id="teacher-nickname-duplicated-check-btn">중복확인
+                            </button>
+                          </div>
+                        </div>
+
+                      </div>
+
+                      <div class="mb-3 col-md-12">
+                        <label class="middle mb-1"><b>개인정보 수집동의 약관</b></label>
+                        <div class="mb-3 col-md-12">
+                                                        <textarea class="form-control" rows="20">
+[ 개인정보 수집동의 ]
+
+EngleBee는 선생님의 수업 경험을 향상시키기 위해 아래와 같은 개인정보를 수집하고 이용합니다.
+선생님 계정으로 가입하시면 다음과 같은 내용에 동의하게 됩니다.
+
+[ 수집하는 개인정보 항목 ]
+
+필수 정보: 이름, 과목 정보, 교육 경력
+선택 정보: 선호 수업 스타일, 특별 지도 경험
+
+[ 개인정보의 수집 및 이용 목적 ]
+
+- 맞춤형 수업 매칭 및 수업 관리 서비스 제공
+
+- 서비스 개선을 위한 데이터 분석 및 통계 작성
+
+- 신규 서비스 개발 및 개인 맞춤형 서비스 제공
+
+[ 개인정보의 보유 및 이용 기간 ]
+
+- 필수 정보 : 이름, 과목 정보, 교육 경력
+해당 정보는 회원 탈퇴 시에도 유지됩니다.
+
+- 선택 정보 : 선호 수업 스타일, 특별 지도 경험
+해당 정보는 회원 탈퇴 시 폐기됩니다.
+
+[ 개인정보 제공 및 공유 ]
+
+EngleBee는 원칙적으로 수집된 개인정보를 외부에 제공하지 않습니다.
+다만, 법령의 규정에 의거하거나 수사 목적으로 법령에 정해진 절차와 방법에 따라
+수사기관의 요구가 있는 경우에는 예외로 합니다.
+
+[ 개인정보 처리의 위탁 ]
+
+EngleBee는 서비스 운영에 필요한 경우 개인정보 처리 업무를 외부 전문 업체에 위탁할 수 있으며,
+이 경우 철저한 관리·감독을 통해 개인정보 보호를 위해 노력합니다.
+
+[ 이용자의 권리와 그 행사 방법 ]
+
+이용자는 언제든지 자신의 개인정보를 조회하거나 수정할 수 있으며,
+개인정보의 수집 및 이용에 대한 동의를 철회할 수 있습니다.
+관련 문의는 고객센터를 통해 가능합니다.
+
+[ 개인정보 보호를 위한 조치 ]
+
+EngleBee는 개인정보 보호를 위해 기술적, 관리적 보호 조치를 시행하고 있으며,
+개인정보 유출 방지를 위해 최선을 다하고 있습니다.
+
+[ 동의 거부 권리 및 동의 거부 시 불이익 안내 ]
+
+이용자는 개인정보 수집 및 이용에 대한 동의를 거부할 권리가 있습니다.
+다만, 동의를 거부할 경우 EngleBee 맞춤형 수업 서비스 이용에 제한이 있을 수 있습니다.
+
+                                                        </textarea>
+                        </div>
+                      </div>
+                      <div class="form-check">
+                        <input class="form-check-input" id="teacher-term-agree-check"
+                               type="checkbox" value="" checked>
+                        <label class="form-check-label"><b>동의합니다.</b></label>
+                      </div>
+                      <hr class="my-4">
+                      <div class="d-flex justify-content-center">
+                        <button class="btn btn-primary" type="button" id="teacher-signup-btn">회원가입
+                        </button>
+                      </div>
+
+                    </form>
+                  </div>
+                </div>
+              </div>
 
             </div>
+          </div>
         </div>
 
+      </div>
+      <!-- --------------------------- [중앙 : 컨텐츠 END]  ------------------------------------->
+    </main>
 
+    <!-- --------------------------- [FRAGMENT : 하단] ------------------------------------->
+    <footer th:replace="~{fragments/footer :: footer}"></footer>
 
-        <!-- 공통 <script> 포함 -->
-      <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
-      <div th:replace="~{fragments/scripts :: scripts}" ></div>
-      <script>
-        $(document).ready(function () {
-          const $studentNicknameInput = $('#student-nickname');
-          const $studentNicknameCheckButton = $('#student-nickname-duplicated-check-btn');
-          const $studentAgreeCheckbox = $('#student-term-agree-check');
-          const $studentSignupButton = $('#student-signup-btn');
+  </div>
+</div>
 
-          $studentSignupButton.prop('disabled', true);
+<!-- 공통 <script> 포함 -->
+<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+<div th:replace="~{fragments/scripts :: scripts}"></div>
+<script>
+  $(document).ready(function () {
+    const $studentNicknameInput = $('#student-nickname');
+    const $studentNicknameCheckButton = $('#student-nickname-duplicated-check-btn');
+    const $studentAgreeCheckbox = $('#student-term-agree-check');
+    const $studentSignupButton = $('#student-signup-btn');
 
-          $studentNicknameCheckButton.on('click', function (event) {
-            event.preventDefault();
-            const nickname = $studentNicknameInput.val().trim();
+    const $teacherNicknameInput = $('#teacher-nickname');
+    const $teacherNicknameCheckButton = $('#teacher-nickname-duplicated-check-btn');
+    const $teacherAgreeCheckbox = $('#teacher-term-agree-check');
+    const $teacherSignupButton = $('#teacher-signup-btn');
 
-            if (nickname === '') {
-              alert('닉네임을 입력하세요.');
-              return;
-            }
+    $studentSignupButton.prop('disabled', true);
+    $teacherSignupButton.prop('disabled', true);
 
-            $.ajax({
-              url: '/api/auth/nickname-duplicated',
-              type: 'POST',
-              contentType: 'application/json',
-              data: JSON.stringify({ 'nickname': nickname }),
-              success: function (response) {
-                alert('사용 가능한 닉네임 입니다.');
-                $studentNicknameCheckButton.removeClass('btn-primary')
-                .addClass('btn-success')
-                .text('사용가능')
-                .prop('disabled', true); // 버튼 비활성화
-                checkFormValidity(); // 폼 유효성 체크
-              },
-              error: function (xhr) {
-                if (xhr.status >= 400 && xhr.status < 500) {
-                  const errorMessage = xhr.responseText || '클라이언트 오류가 발생했습니다.';
-                  alert(errorMessage);
-                } else {
-                  alert('서버 오류가 발생했습니다.');
-                }
-              }
-            });
-          });
+    // 학생 닉네임 중복 확인
+    $studentNicknameCheckButton.on('click', function (event) {
+      event.preventDefault();
+      const nickname = $studentNicknameInput.val().trim();
 
-          $studentNicknameInput.on('input', function () {
-            $studentNicknameCheckButton.removeClass('btn-success')
-            .addClass('btn-primary')
-            .text('중복확인')
-            .prop('disabled', false);
-            checkFormValidity();
-          });
+      if (nickname === '') {
+        alert('닉네임을 입력하세요.');
+        return;
+      }
 
-          // 개인정보 수집 동의 체크박스 변경 시 폼 유효성 체크
-          $studentAgreeCheckbox.on('change', function () {
-            checkFormValidity();
-          });
-
-          function checkFormValidity() {
-            const isNicknameChecked = $studentNicknameCheckButton.hasClass('btn-success');
-            const isAgreeChecked = $studentAgreeCheckbox.is(':checked');
-
-            if (isNicknameChecked && isAgreeChecked) {
-              $studentSignupButton.prop('disabled', false);
-            } else {
-              $studentSignupButton.prop('disabled', true);
-            }
+      $.ajax({
+        url: '/api/auth/nickname-duplicated',
+        type: 'POST',
+        contentType: 'application/json',
+        data: JSON.stringify({'nickname': nickname}),
+        success: function (response) {
+          alert('사용 가능한 닉네임 입니다.');
+          $studentNicknameCheckButton.removeClass('btn-primary')
+          .addClass('btn-success')
+          .text('사용가능')
+          .prop('disabled', true); // 버튼 비활성화
+          checkStudentFormValidity(); // 폼 유효성 체크
+        },
+        error: function (xhr) {
+          if (xhr.status >= 400 && xhr.status < 500) {
+            const errorMessage = xhr.responseText || '클라이언트 오류가 발생했습니다.';
+            alert(errorMessage);
+          } else {
+            alert('서버 오류가 발생했습니다.');
           }
+        }
+      });
+    });
 
-          // 회원가입 버튼 클릭 시 이벤트
-          $studentSignupButton.on('click', function (event) {
-            event.preventDefault();
-            const nickname = $studentNicknameInput.val().trim();
-            const grade = $('#student-grade-select').val();
-            const personalInfoCollectionAgreed = $studentAgreeCheckbox.is(':checked');
+    // 선생님 닉네임 중복 확인
+    $teacherNicknameCheckButton.on('click', function (event) {
+      event.preventDefault();
+      const nickname = $teacherNicknameInput.val().trim();
 
-            const data = {
-              'nickname': nickname,
-              'grade': grade,
-              'personalInfoCollectionAgreed': personalInfoCollectionAgreed
-            };
+      if (nickname === '') {
+        alert('닉네임을 입력하세요.');
+        return;
+      }
 
-            $.ajax({
-              url: '/api/auth/signup/student',
-              type: 'POST',
-              contentType: 'application/json',
-              data: JSON.stringify(data),
-              success: function (response) {
-                alert('회원가입이 성공적으로 완료되었습니다. 다시 로그인 해주세요!');
-                window.location.href = '/main';
-              },
-              error: function (xhr) {
-                if (xhr.status >= 400 && xhr.status < 500) {
-                  const errorMessage = xhr.responseText || '클라이언트 오류가 발생했습니다.';
-                  alert(errorMessage);
-                } else {
-                  alert('서버 오류가 발생했습니다.');
-                }
-              }
-            });
-          });
-        });
-      </script>
+      $.ajax({
+        url: '/api/auth/nickname-duplicated',
+        type: 'POST',
+        contentType: 'application/json',
+        data: JSON.stringify({'nickname': nickname}),
+        success: function (response) {
+          alert('사용 가능한 닉네임 입니다.');
+          $teacherNicknameCheckButton.removeClass('btn-primary')
+          .addClass('btn-success')
+          .text('사용가능')
+          .prop('disabled', true); // 버튼 비활성화
+          checkTeacherFormValidity(); // 폼 유효성 체크
+        },
+        error: function (xhr) {
+          if (xhr.status >= 400 && xhr.status < 500) {
+            const errorMessage = xhr.responseText || '클라이언트 오류가 발생했습니다.';
+            alert(errorMessage);
+          } else {
+            alert('서버 오류가 발생했습니다.');
+          }
+        }
+      });
+    });
 
+    // 학생 닉네임 입력 시 버튼 초기화
+    $studentNicknameInput.on('input', function () {
+      $studentNicknameCheckButton.removeClass('btn-success')
+      .addClass('btn-primary')
+      .text('중복확인')
+      .prop('disabled', false);
+      checkStudentFormValidity();
+    });
 
-</body></html>
+    // 선생님 닉네임 입력 시 버튼 초기화
+    $teacherNicknameInput.on('input', function () {
+      $teacherNicknameCheckButton.removeClass('btn-success')
+      .addClass('btn-primary')
+      .text('중복확인')
+      .prop('disabled', false);
+      checkTeacherFormValidity();
+    });
+
+    // 개인정보 수집 동의 체크박스 변경 시 폼 유효성 체크
+    $studentAgreeCheckbox.on('change', function () {
+      checkStudentFormValidity();
+    });
+
+    $teacherAgreeCheckbox.on('change', function () {
+      checkTeacherFormValidity();
+    });
+
+    function checkStudentFormValidity() {
+      const isNicknameChecked = $studentNicknameCheckButton.hasClass('btn-success');
+      const isAgreeChecked = $studentAgreeCheckbox.is(':checked');
+
+      if (isNicknameChecked && isAgreeChecked) {
+        $studentSignupButton.prop('disabled', false);
+      } else {
+        $studentSignupButton.prop('disabled', true);
+      }
+    }
+
+    function checkTeacherFormValidity() {
+      const isNicknameChecked = $teacherNicknameCheckButton.hasClass('btn-success');
+      const isAgreeChecked = $teacherAgreeCheckbox.is(':checked');
+
+      if (isNicknameChecked && isAgreeChecked) {
+        $teacherSignupButton.prop('disabled', false);
+      } else {
+        $teacherSignupButton.prop('disabled', true);
+      }
+    }
+
+    // 학생 회원가입 버튼 클릭 시 이벤트
+    $studentSignupButton.on('click', function (event) {
+      event.preventDefault();
+      const nickname = $studentNicknameInput.val().trim();
+      const grade = $('#student-grade-select').val();
+      const personalInfoCollectionAgreed = $studentAgreeCheckbox.is(':checked');
+
+      const data = {
+        'nickname': nickname,
+        'grade': grade,
+        'personalInfoCollectionAgreed': personalInfoCollectionAgreed
+      };
+
+      $.ajax({
+        url: '/api/auth/signup/student',
+        type: 'POST',
+        contentType: 'application/json',
+        data: JSON.stringify(data),
+        success: function (response) {
+          alert('회원가입이 성공적으로 완료되었습니다. 다시 로그인 해주세요!');
+          window.location.href = '/main';
+        },
+        error: function (xhr) {
+          if (xhr.status >= 400 && xhr.status < 500) {
+            const errorMessage = xhr.responseText || '클라이언트 오류가 발생했습니다.';
+            alert(errorMessage);
+          } else {
+            alert('서버 오류가 발생했습니다.');
+          }
+        }
+      });
+    });
+
+    // 선생님 회원가입 버튼 클릭 시 이벤트
+    $teacherSignupButton.on('click', function (event) {
+      event.preventDefault();
+      const nickname = $teacherNicknameInput.val().trim();
+      const personalInfoCollectionAgreed = $teacherAgreeCheckbox.is(':checked');
+
+      const data = {
+        'nickname': nickname,
+        'personalInfoCollectionAgreed': personalInfoCollectionAgreed
+      };
+
+      $.ajax({
+        url: '/api/auth/signup/teacher',
+        type: 'POST',
+        contentType: 'application/json',
+        data: JSON.stringify(data),
+        success: function (response) {
+          alert('회원가입이 성공적으로 완료되었습니다. 다시 로그인 해주세요!');
+          window.location.href = '/main';
+        },
+        error: function (xhr) {
+          if (xhr.status >= 400 && xhr.status < 500) {
+            const errorMessage = xhr.responseText || '클라이언트 오류가 발생했습니다.';
+            alert(errorMessage);
+          } else {
+            alert('서버 오류가 발생했습니다.');
+          }
+        }
+      });
+    });
+
+    // 탭 전환 시 폼 상태 초기화
+    $('#wizard1-tab, #wizard2-tab').on('click', function () {
+      resetFormState();
+    });
+
+    function resetFormState() {
+      $studentNicknameCheckButton.removeClass('btn-success')
+      .addClass('btn-primary')
+      .text('중복확인')
+      .prop('disabled', false);
+      $teacherNicknameCheckButton.removeClass('btn-success')
+      .addClass('btn-primary')
+      .text('중복확인')
+      .prop('disabled', false);
+
+      $studentSignupButton.prop('disabled', true);
+      $teacherSignupButton.prop('disabled', true);
+
+      $studentNicknameInput.val('');
+      $teacherNicknameInput.val('');
+
+      $studentAgreeCheckbox.prop('checked', false);
+      $teacherAgreeCheckbox.prop('checked', false);
+    }
+  });
+</script>
+
+</body>
+
+</html>

--- a/src/main/resources/templates/auth/signup-progress.html
+++ b/src/main/resources/templates/auth/signup-progress.html
@@ -13,12 +13,8 @@
             </div>
             <div id="layoutSidenav_content">
                 <main>
-                
-                
                 	<!-- --------------------------- [FRAGMENT : 배너]  ------------------------------------->
                     <div th:replace="~{fragments/top-banner :: top-banner}"></div>
-
-
 
 
                     <!-- --------------------------- [중앙 : 컨텐츠 START]  ------------------------------------->
@@ -64,8 +60,8 @@
                                                         <div class="mb-3 col-md-6">
                                                             <label class="middle mb-1"><b>닉네임을 입력하세요 (최대 20자)</b></label>
                                                             <div class="mb-3 d-flex align-items-center">
-                                                                <input class="form-control me-2" style="width: 300px;" name="nickname" type="text" placeholder="닉네임">
-                                                                <button class="btn btn-primary" style="width: auto;">중복확인</button>
+                                                                <input class="form-control me-2" style="width: 300px;" id="student-nickname" type="text" placeholder="닉네임">
+                                                                <button class="btn btn-primary" style="width: auto;" id="nickname-duplicated-check-btn">중복확인</button>
                                                             </div>
                                                         </div>
 
@@ -120,7 +116,7 @@
                                                         <div class="mb-3 col-md-6">
                                                             <label class="middle mb-1"><b>닉네임을 입력하세요 (최대 20자)</b></label>
                                                             <div class="mb-3 d-flex align-items-center">
-                                                                <input class="form-control me-2" style="width: 300px;" name="nickname" type="text" placeholder="닉네임">
+                                                                <input class="form-control me-2" style="width: 300px;" id="teacher-nickname" type="text" placeholder="닉네임">
                                                                 <button class="btn btn-primary" style="width: auto;">중복확인</button>
                                                             </div>
                                                         </div>
@@ -175,9 +171,57 @@
 
 
 
-
-
         <!-- 공통 <script> 포함 -->
-        <div th:replace="~{fragments/scripts :: scripts}" ></div>
+      <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+      <div th:replace="~{fragments/scripts :: scripts}" ></div>
+      <script>
+        $(document).ready(function () {
+          const $nicknameInput = $('#student-nickname');
+          const $checkButton = $('#nickname-duplicated-check-btn');
+
+          $checkButton.on('click', function (event) {
+            event.preventDefault();
+
+            const nickname = $nicknameInput.val().trim();
+
+            if (nickname === '') {
+              alert('닉네임을 입력하세요.');
+              return;
+            }
+
+            $.ajax({
+              url: '/api/auth/nickname-duplicated',
+              type: 'POST',
+              contentType: 'application/json',
+              data: JSON.stringify({ 'nickname': nickname }),
+              success: function (response) {
+                alert('사용 가능한 닉네임 입니다.');
+                $checkButton.removeClass('btn-primary')
+                .addClass('btn-success')
+                .text('사용가능')
+                .prop('disabled', true); // 버튼 비활성화
+              },
+              error: function (xhr) {
+                if (xhr.status >= 400 && xhr.status < 500) {
+                  const errorMessage = xhr.responseText || '클라이언트 오류가 발생했습니다.';
+                  alert(errorMessage);
+                } else {
+                  alert('서버 오류가 발생했습니다.');
+                }
+              }
+            });
+          });
+
+          // 닉네임 입력값이 변경될 때 버튼을 활성화하고 텍스트를 "중복확인"으로 변경
+          $nicknameInput.on('input', function () {
+            $checkButton.removeClass('btn-success')
+            .addClass('btn-primary')
+            .text('중복확인')
+            .prop('disabled', false); // 버튼 활성화
+          });
+        });
+
+      </script>
+
 
 </body></html>

--- a/src/main/resources/templates/fragments/top-nav-without-menu.html
+++ b/src/main/resources/templates/fragments/top-nav-without-menu.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<body>
+<div th:fragment="top-nav-without-menu">
+
+  <!-- [상단] 네이게이션 바 -->
+  <nav
+      class="topnav navbar navbar-expand shadow justify-content-between justify-content-sm-start navbar-light bg-white"
+      id="sidenavAccordion">
+
+    <!-- 로고 -->
+    <img
+        src="https://www.urbanbrush.net/web/wp-content/uploads/edd/2023/04/urban-20230406152426179707.jpg"
+        width=55>
+    <a class="navbar-brand pe-3 ps-4 ps-lg-2" th:href="@{/main}"><h2><b>EngleBee</b></h2></a>
+
+    <!-- 메뉴 -->
+    <ul class="navbar-nav align-items-center ms-auto">
+    </ul>
+  </nav>
+
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/fragments/top-nav.html
+++ b/src/main/resources/templates/fragments/top-nav.html
@@ -18,7 +18,7 @@
     <ul class="navbar-nav align-items-center ms-auto">
       <li th:if="${session['SESSION_MEMBER'] != null}"
           class="nav-item dropdown no-caret d-none d-md-block me-3"><b><a
-          th:href="@{/exam/detail/1}">수업</a></b></li>
+          th:href="@{/main}">수업</a></b></li>
       <li th:if="${session['SESSION_MEMBER'] != null}"
           class="nav-item dropdown no-caret d-none d-md-block me-3"><b> | </b></li>
       <li th:if="${session['SESSION_MEMBER'] != null}"
@@ -91,7 +91,7 @@
             </div>
           </h6>
           <div class="dropdown-divider"></div>
-          <a class="dropdown-item" href="#!">
+          <a class="dropdown-item" th:href="@{/my/account}">
             <div class="dropdown-item-icon"><i data-feather="settings"></i></div>
             회원정보
           </a>

--- a/src/main/resources/templates/fragments/top-nav.html
+++ b/src/main/resources/templates/fragments/top-nav.html
@@ -1,6 +1,3 @@
-<!-- **************************  레이아웃 공통 ********************* -->
-
-
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
 <body>
@@ -19,22 +16,30 @@
 
     <!-- 메뉴 -->
     <ul class="navbar-nav align-items-center ms-auto">
-      <li class="nav-item dropdown no-caret d-none d-md-block me-3"><b><a
+      <li th:if="${session['SESSION_MEMBER'] != null}"
+          class="nav-item dropdown no-caret d-none d-md-block me-3"><b><a
           th:href="@{/exam/detail/1}">수업</a></b></li>
-      <li class="nav-item dropdown no-caret d-none d-md-block me-3"><b> | </b></li>
-      <li class="nav-item dropdown no-caret d-none d-md-block me-3"><b><a
+      <li th:if="${session['SESSION_MEMBER'] != null}"
+          class="nav-item dropdown no-caret d-none d-md-block me-3"><b> | </b></li>
+      <li th:if="${session['SESSION_MEMBER'] != null}"
+          class="nav-item dropdown no-caret d-none d-md-block me-3"><b><a
           th:href="@{/qna/list}">Q&A</a></b></li>
-      <li class="nav-item dropdown no-caret d-none d-md-block me-3"><b> | </b></li>
-      <li class="nav-item dropdown no-caret d-none d-md-block me-3"><b><a
+      <li th:if="${session['SESSION_MEMBER'] != null}"
+          class="nav-item dropdown no-caret d-none d-md-block me-3"><b> | </b></li>
+      <li th:if="${session['SESSION_MEMBER'] != null}"
+          class="nav-item dropdown no-caret d-none d-md-block me-3"><b><a
           th:href="@{/my/info}">마이페이지</a></b></li>
-      <li class="nav-item dropdown no-caret d-none d-md-block me-3"><b> | </b></li>
-      <li class="nav-item dropdown no-caret d-none d-md-block me-3"><b><a
+      <li th:if="${session['SESSION_MEMBER'] != null}"
+          class="nav-item dropdown no-caret d-none d-md-block me-3"><b> | </b></li>
+      <li th:if="${session['SESSION_MEMBER'] != null}"
+          class="nav-item dropdown no-caret d-none d-md-block me-3"><b><a
           th:href="@{/my/account}">계정</a></b></li>
-      <li class="nav-item dropdown no-caret d-none d-md-block me-3"><b> | </b></li>
-
+      <li th:if="${session['SESSION_MEMBER'] != null}"
+          class="nav-item dropdown no-caret d-none d-md-block me-3"><b> | </b></li>
 
       <!-- 구글/네이버 로그인 드롭다운 -->
-      <li class="nav-item dropdown no-caret d-none d-md-block me-3">
+      <li class="nav-item dropdown no-caret d-none d-md-block me-3"
+          th:if="${session['SESSION_MEMBER'] == null}">
         <a class="nav-link dropdown-toggle" id="navbarDropdownDocs" href="javascript:void(0);"
            role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
           <b>로그인</b>
@@ -69,7 +74,8 @@
       </li>
 
       <!-- 아바타 아이콘 드롭다운 -->
-      <li class="nav-item dropdown no-caret dropdown-user me-3 me-lg-4">
+      <li th:if="${session['SESSION_MEMBER'] != null}"
+          class="nav-item dropdown no-caret dropdown-user me-3 me-lg-4">
         <a class="btn btn-icon btn-transparent-dark dropdown-toggle" id="navbarDropdownUserImage"
            href="javascript:void(0);" role="button" data-bs-toggle="dropdown" aria-haspopup="true"
            aria-expanded="false"><img class="img-fluid"

--- a/src/main/resources/templates/general/exam-detail.html
+++ b/src/main/resources/templates/general/exam-detail.html
@@ -19,9 +19,6 @@
 
             <!-- --------------------------- [중앙 : 컨텐츠 START]  ------------------------------------->
 
-
-
-
                     <div class="container-xl px-4 mt-n10">
                         <!-- Wizard card example with navigation-->
                         <div class="card">

--- a/src/main/resources/templates/student/student-main.html
+++ b/src/main/resources/templates/student/student-main.html
@@ -125,7 +125,7 @@
                                                 
 	                                                  <div class="d-flex justify-content-between align-items-center">
 												        <h1 class="text-google"><b>제출 완료한 시험<br><br></b></h1>
-												        <a class="text-arrow-icon small text-danger fw-bold ms-auto" href="/my">더보기...</a>
+												        <a class="text-arrow-icon small text-danger fw-bold ms-auto" th:href="@{/my/info}">더보기...</a>
 												      </div>
 	                                                  <table class="datatable-table">
 	                                                  	<tr>


### PR DESCRIPTION
## 👀 관련 이슈

close #52 

## ✨ 작업 내용

<!-- 이번 PR에서 작업한 내용을 리스트 형식으로 작성해주세요. (이미지 첨부 가능) -->

- 학생/선생님 멤버로 네이버, 구글 로그인/회원가입 기능(API)와 타임리프 뷰 연동을 완료했습니다.
- 세션 유무에 따라 메인 페이지와 추가회원가입 페이지의 뷰 연동이 다르게 나타나도록 뷰를 수정했습니다.
- 전체적인 타임리프 뷰에서 내부 라우팅이 덜 된/ 잘못된 부분을 수정했습니다.
- 시큐리티의 csrf 설정 해제 및 수업 / Q&A / 마이페이지 / 계정 페이지로 이동에 대한 인증/인가 설정을 추가했습니다.
- 회원탈퇴된 유저가 로그인하지 못하고 메인 페이지로 돌아가는 기능을 구현했습니다.

## 📸 스크린샷

<!-- (선택) 작업 내용을 설명할 수 있는 관련 화면을 스크린샷으로 남겨주세요. (없는 경우 '없음'이라 작성해주세요.) -->

- 없음

## 🙏 리뷰 요구 사항

<!-- 리뷰어가 특별히 봐주었으면 하는 부분을 알려주세요. -->

- 없음

## 📢 논의하고 싶은 내용

<!-- (선택) 논의하고 싶은 내용 작성해주세요.
ex) 메서드 xxx의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? 
(없는 경우 '없음'이라 작성해주세요.) -->

- 없음

## 🎸 기타 사항

<!-- (선택) 다른 개발자분들이 인지해놓는다면 좋은 내용들이나 특이사항이 있다면 남겨주세요. 
(없는 경우 '없음'이라 작성해주세요.)-->

- 없음