### PR TITLE
[feat-student-main-view] 학생 메인 페이지 구현

### DIFF
--- a/src/main/java/com/beelinkers/englebee/general/controller/page/MainPageController.java
+++ b/src/main/java/com/beelinkers/englebee/general/controller/page/MainPageController.java
@@ -3,7 +3,12 @@ package com.beelinkers.englebee.general.controller.page;
 import com.beelinkers.englebee.auth.annotation.LoginMember;
 import com.beelinkers.englebee.auth.domain.entity.Role;
 import com.beelinkers.englebee.auth.oauth2.session.SessionMember;
+import com.beelinkers.englebee.general.domain.entity.LectureStatus;
+import com.beelinkers.englebee.general.domain.repository.LectureRepository;
 import com.beelinkers.englebee.general.service.MainPageService;
+import com.beelinkers.englebee.student.dto.response.StudentMainPageLectureDTO;
+import com.beelinkers.englebee.student.service.StudentMainService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Controller;
@@ -16,6 +21,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 public class MainPageController {
 
   private final MainPageService mainPageService;
+  private final StudentMainService studentMainService;
+  private final LectureRepository lectureRepository;
 
   @GetMapping("/main")
   public String getMainPage(@LoginMember SessionMember sessionMember, Model model) {
@@ -24,12 +31,26 @@ public class MainPageController {
     }
 
     Long memberSeq = sessionMember.getSeq();
+    List<StudentMainPageLectureDTO> lectures = studentMainService.getOngoingLectureInfo(
+        memberSeq, null, LectureStatus.CREATED);
+
+    // 강의가 존재하는 경우 첫 번째 강의 정보를 모델에 전달
+    if (!lectures.isEmpty()) {
+      Long lectureSeq = lectures.get(0).getLectureSeq(); // 첫 번째 강의의 lectureSeq 가져오기
+      model.addAttribute("lectureSeq", lectureSeq); // lectureSeq를 모델에 추가
+//      log.info("lectureSeq : {}", lectureSeq);
+    } else {
+      model.addAttribute("lectureSeq", null); // 강의가 없을 경우 null 전달
+    }
+
     model.addAttribute("nickname", mainPageService.getNickname(memberSeq));
     model.addAttribute("memberSeq", memberSeq);
+    model.addAttribute("lectures", lectures);
 
     Role sessionUserRole = sessionMember.getRole();
     if (sessionUserRole.isStudent()) {
       return "student/student-main";
+
     } else if (sessionUserRole.isTeacher()) {
       return "teacher/teacher-main";
     }

--- a/src/main/java/com/beelinkers/englebee/general/domain/repository/LectureRepository.java
+++ b/src/main/java/com/beelinkers/englebee/general/domain/repository/LectureRepository.java
@@ -5,16 +5,19 @@ import com.beelinkers.englebee.general.domain.entity.LectureStatus;
 import java.util.List;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface LectureRepository extends JpaRepository<Lecture, Long> {
 
   // 학생 수강 목록 조회
   @EntityGraph(attributePaths = {"subjectLevels.subjectLevel", "teacher"})
+  @Query("SELECT l FROM Lecture l WHERE l.student.seq = :studentSeq AND (:lectureSeq IS NULL OR l.seq = :lectureSeq) AND l.status = :lectureStatus")
   List<Lecture> findByStudentSeqAndSeqAndStatus(Long studentSeq, Long lectureSeq,
       LectureStatus lectureStatus);
 
   // 선생님 강의 목록 조회
   @EntityGraph(attributePaths = {"subjectLevels.subjectLevel", "student"})
+  @Query("SELECT l FROM Lecture l WHERE l.teacher.seq = :teacherSeq AND (:lectureSeq IS NULL OR l.seq = :lectureSeq) AND l.status = :status")
   List<Lecture> findByTeacherSeqAndSeqAndStatus(Long teacherSeq, Long lectureSeq,
       LectureStatus status);
 }

--- a/src/main/java/com/beelinkers/englebee/student/dto/response/StudentMainPageLectureDTO.java
+++ b/src/main/java/com/beelinkers/englebee/student/dto/response/StudentMainPageLectureDTO.java
@@ -12,6 +12,7 @@ import lombok.NoArgsConstructor;
 public class StudentMainPageLectureDTO {
 
   private Long id;
+  private Long lectureSeq;
   private String teacherNickname;
   private String title;
   private String status;

--- a/src/main/java/com/beelinkers/englebee/student/dto/response/mapper/StudentMainPageMapper.java
+++ b/src/main/java/com/beelinkers/englebee/student/dto/response/mapper/StudentMainPageMapper.java
@@ -29,6 +29,7 @@ public class StudentMainPageMapper {
 
     return new StudentMainPageLectureDTO(
         lecture.getSeq(),
+        lecture.getSeq(),
         lecture.getTeacher().getNickname(),
         lecture.getTitle(),
         lecture.getStatus().name(),

--- a/src/main/java/com/beelinkers/englebee/teacher/dto/response/TeacherMainPageLectureDTO.java
+++ b/src/main/java/com/beelinkers/englebee/teacher/dto/response/TeacherMainPageLectureDTO.java
@@ -12,6 +12,7 @@ import lombok.NoArgsConstructor;
 public class TeacherMainPageLectureDTO {
 
   private Long id;
+  private Long lectureSeq;
   private String studentNickname;
   private String title;
   private String status;

--- a/src/main/java/com/beelinkers/englebee/teacher/dto/response/mapper/TeacherMainPageMapper.java
+++ b/src/main/java/com/beelinkers/englebee/teacher/dto/response/mapper/TeacherMainPageMapper.java
@@ -29,6 +29,7 @@ public class TeacherMainPageMapper {
 
     return new TeacherMainPageLectureDTO(
         lecture.getSeq(),
+        lecture.getSeq(),
         lecture.getStudent().getNickname(),
         lecture.getTitle(),
         lecture.getStatus().name(),

--- a/src/main/resources/templates/student/student-main.html
+++ b/src/main/resources/templates/student/student-main.html
@@ -1,195 +1,396 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
 
-<head th:replace="~{fragments/header :: head}"></head>
+<head th:replace="~{fragments/header :: head}">
+  <style>
+    .datatable-table > tr {
+      padding: 10px;
+    }
+  </style>
+</head>
 
 
-<body  class="bg-white">
-    
-    	<!-- --------------------------- [FRAGMENT : 상단 네이게이션바]  ------------------------------------->
-        <div th:replace="~{fragments/top-nav :: top-nav}"></div>
-        
-        
-        
-        
-        <div id="layoutSidenav">
-            <div id="layoutSidenav_nav">
-            </div>
-            <div id="layoutSidenav_content">
-                <main>
-                
-                
-                	<!-- --------------------------- [FRAGMENT : 배너]  ------------------------------------->
-                    <div th:replace="~{fragments/top-banner :: top-banner}"></div>
+<body class="bg-white">
+
+<!-- --------------------------- [FRAGMENT : 상단 네이게이션바]  ------------------------------------->
+<div th:replace="~{fragments/top-nav :: top-nav}"></div>
 
 
+<div id="layoutSidenav">
+  <div id="layoutSidenav_nav">
+  </div>
+  <div id="layoutSidenav_content">
+    <main>
 
 
-                    <!-- --------------------------- [중앙 : 컨텐츠 START]  ------------------------------------->
-                    <div class="container-xl px-4 mt-n10">
-                        <div class="row">
+      <!-- --------------------------- [FRAGMENT : 배너]  ------------------------------------->
+      <div th:replace="~{fragments/top-banner :: top-banner}"></div>
 
-                        	<!-- 학생 : 현재 수강 가능한 강의 -->
-                            <div class="col-xxl-4 col-xl-12 mb-4">
-                                <div class="card h-100">
-                                    <div class="card-body h-100 p-5">
-                                        <div class="row align-items-center">
-                                            <div class="col-xl-8 col-xxl-12">
-                                                <div class="text-center text-xl-start text-xxl-center mb-4 mb-xl-0 mb-xxl-4">
-                                                    <h1 class="text-google"><b>현재 수강 가능한 강의<br><br></b></h1>
-                                                    <table class="datatable-table">
-                                                    	<tr><th>강의명</th><td>할수있다 자바</td></tr>
-                                                    	<tr><th>선생님</th><td>아무개</td></tr>
-                                                    	<tr><th>수업일</th><td>2022-10-12 10:24:57</td></tr>
-                                                    	<tr>
-                                                    		<th>과목 및 레벨</th>
-                                                    		<td>
-                                                    			<p><div class="badge bg-info rounded-pill">문법 : 중</div></p>
-                                                    			<p><div class="badge bg-primary text-white rounded-pill">어휘 : 하</div></p>
-                                                    			<p><div class="badge bg-warning rounded-pill">문법 : 중</div></p>
-                                                    			<p><div class="badge bg-secondary text-white rounded-pill">어휘 : 하</div></p>
-                                                    		</td>
-                                                    	</tr>
-                                                    </table>
-                                                    <a class="btn btn-primary btn-sm" th:href="@{/chat}" target="_blank">
-			                                            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-external-link me-1"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path><polyline points="15 3 21 3 21 9"></polyline><line x1="10" y1="14" x2="21" y2="3"></line></svg>
-			                                           강의실 입장
-			                                        </a>
-			                                        
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                            
-                            <!-- 풀어야 할 시험 -->
-                            <div class="col-xxl-4 col-xl-12 mb-4">
-                                <div class="card h-100">
-                                    <div class="card-body h-100 p-5">
-                                        <div class="row align-items-center">
-                                            <div class="col-xl-8 col-xxl-12">
-                                                <div class="text-center text-xl-start text-xxl-center mb-4 mb-xl-0 mb-xxl-4">
-                                                
-	                                                  <div class="d-flex justify-content-between align-items-center">
-												        <h1 class="text-google"><b>풀어야 할 시험<br><br></b></h1>
-												        <a class="text-arrow-icon small text-danger fw-bold ms-auto" th:href="@{/my/info}">더보기...</a>
-												      </div>
-	                                                  <table class="datatable-table">
-	                                                  	<tr>
-	                                                  		<th>강의명</th>
-	                                                  		<th>선생님</th>
-	                                                  		<th>등록일</th>
-	                                                  	</tr>
-	                                                  	<tr>
-	                                                  		<td><a th:href="@{/exam/detail/1}">lec01.할수있다 자바</a></td>
-	                                                  		<td>홍길동</td>
-	                                                  		<td>2024-01-01</td>
-	                                                  	</tr>
-	                                                  	<tr>
-	                                                  		<td><a th:href="@{/exam/detail/2}">lec02.할수있다 자바</a></td>
-	                                                  		<td>홍길동</td>
-	                                                  		<td>2024-01-01</td>
-	                                                  	</tr>
-	                                                  	<tr>
-	                                                  		<td><a th:href="@{/exam/detail/3}">lec03.할수있다 자바</a></td>
-	                                                  		<td>홍길동</td>
-	                                                  		<td>2024-01-01</td>
-	                                                  	</tr>
-	                                                  	<tr>
-	                                                  		<td><a th:href="@{/exam/detail/4}">lec04.할수있다 자바</a></td>
-	                                                  		<td>홍길동</td>
-	                                                  		<td>2024-01-01</td>
-	                                                  	</tr>
-	                                                  	<tr>
-	                                                  		<td><a th:href="@{/exam/detail/5}">lec05.할수있다 자바</a></td>
-	                                                  		<td>홍길동</td>
-	                                                  		<td>2024-01-01</td>
-	                                                  	</tr>
-	                                                  </table>
-                                                    
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                            
-                            <!-- 제출 완료한 시험 -->
-                            <div class="col-xxl-4 col-xl-12 mb-4">
-                                <div class="card h-100">
-                                    <div class="card-body h-100 p-5">
-                                        <div class="row align-items-center">
-                                            <div class="col-xl-8 col-xxl-12">
-                                                <div class="text-center text-xl-start text-xxl-center mb-4 mb-xl-0 mb-xxl-4">
-                                                
-	                                                  <div class="d-flex justify-content-between align-items-center">
-												        <h1 class="text-google"><b>제출 완료한 시험<br><br></b></h1>
-												        <a class="text-arrow-icon small text-danger fw-bold ms-auto" th:href="@{/my/info}">더보기...</a>
-												      </div>
-	                                                  <table class="datatable-table">
-	                                                  	<tr>
-	                                                  		<th>강의명</th>
-	                                                  		<th>선생님</th>
-	                                                  		<th>등록일</th>
-	                                                  	</tr>
-	                                                  	<tr>
-	                                                  		<td><a th:href="@{/exam/detail/1}">lec01.할수있다 자바</a></td>
-	                                                  		<td>홍길동</td>
-	                                                  		<td>2024-01-01</td>
-	                                                  	</tr>
-	                                                  	<tr>
-	                                                  		<td><a th:href="@{/exam/detail/2}">lec02.할수있다 자바</a></td>
-	                                                  		<td>홍길동</td>
-	                                                  		<td>2024-01-01</td>
-	                                                  	</tr>
-	                                                  	<tr>
-	                                                  		<td><a th:href="@{/exam/detail/3}">lec03.할수있다 자바</a></td>
-	                                                  		<td>홍길동</td>
-	                                                  		<td>2024-01-01</td>
-	                                                  	</tr>
-	                                                  	<tr>
-	                                                  		<td><a th:href="@{/exam/detail/4}">lec04.할수있다 자바</a></td>
-	                                                  		<td>홍길동</td>
-	                                                  		<td>2024-01-01</td>
-	                                                  	</tr>
-	                                                  	<tr>
-	                                                  		<td><a th:href="@{/exam/detail/5}">lec05.할수있다 자바</a></td>
-	                                                  		<td>홍길동</td>
-	                                                  		<td>2024-01-01</td>
-	                                                  	</tr>
-	                                                  </table>
-                                                    
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                                                        
-                            
-                        </div>
+
+      <!-- --------------------------- [중앙 : 컨텐츠 START]  ------------------------------------->
+      <div class="container-xl px-4 mt-n10">
+        <div class="row">
+
+          <!-- 학생 : 현재 수강 가능한 강의 -->
+          <div class="col-xxl-4 col-xl-12 mb-4">
+            <div class="card h-100">
+              <div class="card-body h-100 p-5">
+                <div class="row align-items-center">
+                  <div class="col-xl-8 col-xxl-12">
+                    <div class="text-center text-xl-start text-xxl-center mb-4 mb-xl-0 mb-xxl-4">
+                      <h1 class="text-google"><b>현재 수강 가능한 강의<br><br></b></h1>
+                      <table class="datatable-table" id="lectureList">
+                        <!-- 강의 데이터가 동적으로 추가될 부분 -->
+                      </table>
+                      <a class="btn btn-primary btn-sm" id="enterLecture" href="#" target="_blank"
+                         style="display:none;">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                             viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                             stroke-linecap="round" stroke-linejoin="round"
+                             class="feather feather-external-link me-1">
+                          <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
+                          <polyline points="15 3 21 3 21 9"></polyline>
+                          <line x1="10" y1="14" x2="21" y2="3"></line>
+                        </svg>
+                        강의실 입장
+                      </a>
                     </div>
-                    <!-- --------------------------- [중앙 : 컨텐츠 END]  ------------------------------------->
-                    
-                    
-                </main>
-                
-                
-                
-                <!-- --------------------------- [FRAGMENT : 하단] ------------------------------------->
-                <footer th:replace="~{fragments/footer :: footer}"></footer>
-
-
-
+                  </div>
+                </div>
+              </div>
             </div>
+          </div>
+
+          <!-- 풀어야 할 시험 -->
+          <div class="col-xxl-4 col-xl-12 mb-4">
+            <div class="card h-100">
+              <div class="card-body h-100 p-5">
+                <div class="row align-items-center">
+                  <div class="col-xl-8 col-xxl-12">
+                    <div class="text-center text-xl-start text-xxl-center mb-4 mb-xl-0 mb-xxl-4">
+                      <h1 class="text-google"><b>풀어야 할 시험<br><br></b></h1>
+                      <table class="datatable-table">
+                        <thead>
+                        <tr>
+                          <th>시험명</th>
+                          <th>선생님</th>
+                          <th>등록일</th>
+                        </tr>
+                        </thead>
+                        <tbody id="createdExamList">
+                        <!-- 준비된 시험 데이터가 동적으로 추가될 부분 -->
+                        </tbody>
+                      </table>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- 제출 완료한 시험 -->
+          <div class="col-xxl-4 col-xl-12 mb-4">
+            <div class="card h-100">
+              <div class="card-body h-100 p-5">
+                <div class="row align-items-center">
+                  <div class="col-xl-8 col-xxl-12">
+                    <div class="text-center text-xl-start text-xxl-center mb-4 mb-xl-0 mb-xxl-4">
+                      <h1 class="text-google"><b>제출 완료한 시험<br><br></b></h1>
+                      <table class="datatable-table">
+                        <thead>
+                        <tr>
+                          <th>시험명</th>
+                          <th>선생님</th>
+                          <th>등록일</th>
+                        </tr>
+                        </thead>
+                        <tbody id="completedExamList">
+                        <!-- 완료된 시험 데이터가 동적으로 추가될 부분 -->
+                        </tbody>
+                      </table>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+
         </div>
+      </div>
+      <!-- --------------------------- [중앙 : 컨텐츠 END]  ------------------------------------->
 
 
+    </main>
+
+
+    <!-- --------------------------- [FRAGMENT : 하단] ------------------------------------->
+    <footer th:replace="~{fragments/footer :: footer}"></footer>
+
+
+  </div>
+</div>
 
 
 <!-- 공통 <script> 포함 -->
-<div th:replace="~{fragments/scripts :: scripts}" ></div>
+<div th:replace="~{fragments/scripts :: scripts}"></div>
+<script src="https://cdn.jsdelivr.net/npm/dayjs@1/dayjs.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+<input type="hidden" id="memberSeq" th:value="${memberSeq}">
+<input type="hidden" id="lectureSeq" th:value="${lectureSeq}">
+<script>
+  $(document).ready(function () {
+    let memberSeq = $("#memberSeq").val();
+    let lectureSeq = $("#lectureSeq").val();
+    let status = 'CREATED';
+
+    if (lectureSeq && lectureSeq !== '') {
+      fetchLectures(memberSeq, lectureSeq, status);
+    }
+    examPending(memberSeq);
+    finishExam(memberSeq);
+
+    function fetchLectures(memberSeq, lectureSeq, status) {
+      $.ajax({
+        url: '/api/student/main/lecture?memberSeq=' + memberSeq + '&lectureSeq=' + lectureSeq
+            + '&lectureStatus=' + status,
+        type: 'GET',
+        dataType: 'json',
+        success: function (data) {
+          let lectureHtml = '';
+          let lectureList = $('#lectureList');
+          lectureList.empty(); // 기존 데이터를 지우고 새 데이터를 추가
+          if (data.length > 0) {
+            data.forEach(function (lecture) {
+              lectureHtml += `
+            <tr>
+              <th>강의명</th>
+              <td>${lecture.title}</td>
+            </tr>
+            `;
+              lectureHtml += `
+            <tr>
+              <th>선생님</th>
+              <td>${lecture.teacherNickname}</td>
+            </tr>
+            `;
+              lectureHtml += `
+            <tr>
+              <th>수업일</th>
+              <td>${new Date(lecture.createdAt).toLocaleString()}</td>
+            </tr>
+            `;
+              lectureHtml += `
+            <tr>
+              <th>과목 및 레벨</th>
+              <td>
+                <div class="badge bg-info rounded-pill">${lecture.subjectLevelCode.subjectCode}</div>
+                <div class="badge bg-primary text-white rounded-pill">${lecture.subjectLevelCode.levelCode}</div>
+              </td>
+            </tr>
+            `;
+              lectureList.append(lectureHtml);
+            });
+
+            // 첫 번째 강의실 입장 링크 설정
+            let firstLectureSeq = data[0].id;
+            $('#enterLecture').attr('href', `/chat/${firstLectureSeq}`).show();
+          } else {
+            $('#lectureList').html('<p>현재 수강 가능한 강의가 없습니다.</p>');
+          }
+        },
+        error: function () {
+          $('#lectureList').html('<p>강의 데이터를 불러오는 중 오류가 발생했습니다.</p>');
+        }
+      });
+    }
+
+    // function fetchLectures(memberSeq, lectureSeq, status) {
+    //   $.ajax({
+    //     url: '/api/student/main/lecture?memberSeq=' + memberSeq + '&lectureSeq=' + lectureSeq
+    //         + '&lectureStatus=' + status,
+    //     type: 'GET',
+    //     dataType: 'json',
+    //     success: function (data) {
+    //       console.log(data);
+    //       let lectureList = $('#lectureList');
+    //       lectureList.empty(); // 기존 데이터를 지우고 새 데이터를 추가
+    //       let lectureHtml = '';
+    //       if (data.length > 0) {
+    //         data.forEach(function (lecture) {
+    //           lectureHtml += `
+    //         <tr>
+    //           <th>강의명</th>
+    //           <td>${lecture.title}</td>
+    //         </tr>
+    //         `;
+    //           lectureHtml += `
+    //         <tr>
+    //           <th>선생님</th>
+    //           <td>${lecture.teacherNickname}</td>
+    //         </tr>
+    //         `;
+    //           lectureHtml += `
+    //         <tr>
+    //           <th>수업일</th>
+    //           <td>${new Date(lecture.createdAt).toLocaleString()}</td>
+    //         </tr>
+    //         `;
+    //           lectureHtml += `
+    //         <tr>
+    //           <th>과목 및 레벨</th>
+    //           <td>
+    //             ${lecture.subjectLevelCode.subjectCode.map(function (subject, index) {
+    //             return `
+    //                 <div class="badge bg-info rounded-pill">${subject}</div>
+    //                 <div class="badge bg-primary text-white rounded-pill">${lecture.subjectLevelCode.levelCode[index]}</div>
+    //               `;
+    //           }).join('')}
+    //           </td>
+    //         </tr>
+    //         `;
+    //           lectureList.append(lectureHtml);
+    //         });
+    //
+    //         // 첫 번째 강의실 입장 링크 설정
+    //         const firstLectureSeq = data[0].id;
+    //         $('#enterLecture').attr('href', `/chat/${firstLectureSeq}`).show();
+    //       } else {
+    //         lectureList.html('<p>현재 수강 가능한 강의가 없습니다.</p>');
+    //       }
+    //     },
+    //     error: function () {
+    //       $('#lectureList').html('<p>강의 데이터를 불러오는 중 오류가 발생했습니다.</p>');
+    //     }
+    //   });
+    // }
+
+//     function fetchLectures(memberSeq, lectureSeq, status) {
+//       $.ajax({
+//         url: '/api/student/main/lecture?memberSeq=' + memberSeq + '&lectureSeq=' + lectureSeq
+//             + '&lectureStatus=' + status, // 실제 API 경로로 수정
+//         type: 'GET',
+//         dataType: 'json',
+//         success: function (data) {
+//           console.log(data);
+//           let lectureList = $('#lectureList');
+//           lectureList.empty(); // 기존 데이터를 지우고 새 데이터를 추가
+//           let lectureHtml = '';
+//           if (data.length > 0) {
+//             data.forEach(function (lecture) {
+//               lectureHtml += `            <tr>
+//               <th>강의명</th>
+//               <td>${lecture.lectureTitle}</td>
+//             </tr>
+//             `;
+//               lectureHtml += `
+//             <tr>
+//               <th>선생님</th>
+//               <td>${lecture.teacherName}</td>
+//             </tr>
+//             `;
+//               lectureHtml += `
+//             <tr>
+//               <th>수업일</th>
+//               <td>${new Date(lecture.lectureDate).toLocaleString()}</td>
+//             </tr>
+//             `;
+//               lectureHtml += `
+// <tr>
+//               <th>과목 및 레벨</th>
+//               <td>
+//                 ${lecture.subjectLevels.map(function (subjectLevel) {
+//                 return `
+//                     <div class="badge bg-info rounded-pill">${subjectLevel.subject}</div>
+//                     <div class="badge bg-primary text-white rounded-pill">${subjectLevel.level}</div>
+//                   `;
+//               }).join('')}
+//               </td>
+//             </tr>
+//             `;
+//               lectureList.append(lectureHtml);
+//             });
+//
+//             // 첫 번째 강의실 입장 링크 설정
+//             const firstLectureSeq = data[0].seq;
+//             $('#enterLecture').attr('href', `/chat/${firstLectureSeq}`).show();
+//           } else {
+//             lectureList.html('<p>현재 수강 가능한 강의가 없습니다.</p>');
+//           }
+//         },
+//         error: function () {
+//           $('#lectureList').html('<p>강의 데이터를 불러오는 중 오류가 발생했습니다.</p>');
+//         }
+//       });
+//     }
+
+    function examPending(memberSeq) {
+      $.ajax({
+        url: '/api/student/main/created-exam?memberSeq=' + memberSeq,
+        method: 'GET',
+        success: function (response) {
+
+          $("#createdExamList").empty();
+
+          if (response.length === 0) {
+            $("#createdExamList").html('<tr><td colspan="3">현재 생성된 시험이 없습니다.</td></tr>');
+          } else {
+            $.each(response, function (index, exam) {
+              let createdDate = dayjs(exam.createdAt).isValid() ? dayjs(exam.createdAt).format(
+                  'YYYY-MM-DD') : '날짜 없음';
+
+              var examHTML = `
+            <tr>
+              <td><a href="/exam/detail/${exam.lectureSeq}">${exam.title}</a></td>
+              <td>${exam.teacherNickname}</td>
+              <td>${createdDate}</td>
+            </tr>`;
+
+              $("#createdExamList").append(examHTML);
+            });
+          }
+        },
+        error: function (xhr, status, error) {
+          console.log("Error: " + error);
+          $("#createdExamList").html('<tr><td colspan="3">시험 데이터를 불러오는 중 오류가 발생했습니다.</td></tr>');
+        }
+      });
+    }
+
+    function finishExam(memberSeq) {
+      $.ajax({
+        url: '/api/student/main/completed-exam?memberSeq=' + memberSeq,
+        method: 'GET',
+        success: function (response) {
+          $("#completedExamList").empty();
+
+          // 응답 데이터가 비어있는 경우 처리
+          if (response.length === 0) {
+            $("#completedExamList").html('<tr><td colspan="3">현재 완료된 시험이 없습니다.</td></tr>');
+          } else {
+            $.each(response, function (index, exam) {
+              let createdDate = dayjs(exam.createdAt).isValid() ? dayjs(exam.createdAt).format(
+                  'YYYY-MM-DD') : '날짜 없음';
+
+              var examHTML = `
+            <tr>
+              <td><a href="/exam/detail/${exam.lectureSeq}">${exam.examTitle}</a></td>
+              <td>${exam.teacherName}</td>
+              <td>${createdDate}</td>
+            </tr>`;
+              $("#completedExamList").append(examHTML);
+            });
+          }
+        },
+        error: function (xhr, status, error) {
+          console.log("Error: " + error);
+          $("#createdExamList").html('<tr><td colspan="3">시험 데이터를 불러오는 중 오류가 발생했습니다.</td></tr>');
+        }
+      });
+    }
+  });
+
+</script>
 
 </body>
 </html>


### PR DESCRIPTION
## 👀 관련 이슈

close #81 

## ✨ 작업 내용

<!-- 이번 PR에서 작업한 내용을 리스트 형식으로 작성해주세요. (이미지 첨부 가능) -->

- 진행할 수업을 확인 할 수 있다.
- 제출한 시험 리스트를 확인 할 수 있다. 
- 출제한 시험 리스트를 확인 할 수 있다.
- 리스트에서 제목이나 게시글 내용을 클릭하면 해당 게시글의 상세 페이지로 이동 가능하다.
- 더보기 클릭 시, 내가 작성한 my 페이지로 이동된다.

## 📸 스크린샷

<!-- (선택) 작업 내용을 설명할 수 있는 관련 화면을 스크린샷으로 남겨주세요. (없는 경우 '없음'이라 작성해주세요.) -->

![스크린샷(490)](https://github.com/user-attachments/assets/9f87f3d7-8d23-47f8-974c-3e3868bd4054)
![스크린샷(492)](https://github.com/user-attachments/assets/25a9e7d4-b09e-49d0-9c8b-1522574f26ac)


## 🙏 리뷰 요구 사항

<!-- 리뷰어가 특별히 봐주었으면 하는 부분을 알려주세요. -->

- 없음

## 📢 논의하고 싶은 내용

<!-- (선택) 논의하고 싶은 내용 작성해주세요.
ex) 메서드 xxx의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? 
(없는 경우 '없음'이라 작성해주세요.) -->

- 없음

## 🎸 기타 사항

<!-- (선택) 다른 개발자분들이 인지해놓는다면 좋은 내용들이나 특이사항이 있다면 남겨주세요. 
(없는 경우 '없음'이라 작성해주세요.)-->

- 없음